### PR TITLE
Modernpython

### DIFF
--- a/CIMgen.py
+++ b/CIMgen.py
@@ -436,7 +436,7 @@ def _parse_rdf(input_dic, version):
         else:
             logger.info("Class {} for instance {} not found.".format(clarse, instance))
 
-    return {short_profile_name: classes_map} # UNO RETUENS PROFIENAME
+    return {short_profile_name: classes_map}
 
 
 # This function extracts all information needed for the creation of the python class files like the comments or the
@@ -532,7 +532,7 @@ def _write_files(class_details, outputPath, version):
             _dataType = attr['dataType']
         attr['class_name'] = format_class( _range, _dataType )
 
-    class_details['langPack'].run_template( outputPath, class_details ) # WHAT IS TAHT ONE? DELTED IN UNO
+    class_details['langPack'].run_template( outputPath, class_details )
 
 # Find multiple entries for the same attribute
 def _find_multiple_attributes(attributes_array):

--- a/CIMgen.py
+++ b/CIMgen.py
@@ -1,10 +1,15 @@
-import os
-import xmltodict
-from time import time
+import html
 import json
-
 import logging
+import os
+import textwrap
+from time import time
+
+import xmltodict
+from bs4 import BeautifulSoup
+
 logger = logging.getLogger(__name__)
+
 
 class RDFSEntry:
     def __init__(self, jsonObject):
@@ -39,6 +44,7 @@ class RDFSEntry:
             jsonObject['inverseRole'] = self.inverseRole()
         if self.associationUsed() != None:
             jsonObject['associationUsed'] = self.associationUsed()
+        jsonObject["isAssociationUsed"] = self.isAssociationUsed()
         return jsonObject
 
     def about(self):
@@ -52,6 +58,12 @@ class RDFSEntry:
             return RDFSEntry._extract_string(self.jsonDefinition['cims:AssociationUsed'])
         else:
             return None
+
+    def isAssociationUsed(self) -> bool:
+        if "cims:AssociationUsed" in self.jsonDefinition:
+            return "yes" == RDFSEntry._extract_string(self.jsonDefinition["cims:AssociationUsed"]).lower()
+        else:
+            return True
 
     def comment(self):
         if 'rdfs:comment' in self.jsonDefinition:
@@ -277,6 +289,22 @@ def get_short_profile_name(descriptions):
         if rdfsEntry.label() == 'shortName':
             return rdfsEntry.fixed()
 
+
+def wrap_and_clean(txt: str, width: int = 120, initial_indent="", subsequent_indent="    ") -> str:
+    """
+    Used for comments: make them fit within <width> character, including indentation.
+    """
+    soup = BeautifulSoup(txt, "html.parser")
+    return "\n".join(
+        textwrap.wrap(
+            soup.text,
+            width=width,
+            initial_indent=initial_indent,
+            subsequent_indent=subsequent_indent,
+        )
+    )
+
+
 short_package_name = {}
 package_listed_by_short_name = {}
 
@@ -307,15 +335,15 @@ def _rdfs_entry_types(rdfs_entry: RDFSEntry, version)->list:
 def _entry_types_version_2(rdfs_entry: RDFSEntry) -> list:
     entry_types=[]
     if rdfs_entry.stereotype() != None:
-            if rdfs_entry.stereotype() == "Entsoe" and rdfs_entry.about()[-7:] == "Version":
-                entry_types.append("profile_name_v2_4")
-            if (
-                rdfs_entry.stereotype() == "http://iec.ch/TC57/NonStandard/UML#attribute" # NOSONAR
-                and rdfs_entry.label()[0:7] == "baseURI"
-            ):
-                entry_types.append("profile_iri_v2_4")
-            if rdfs_entry.label() == "shortName":
-                entry_types.append("short_profile_name_v2_4")
+        if rdfs_entry.stereotype() == "Entsoe" and rdfs_entry.about()[-7:] == "Version":
+            entry_types.append("profile_name_v2_4")
+        if (
+            rdfs_entry.stereotype() == "http://iec.ch/TC57/NonStandard/UML#attribute" # NOSONAR
+            and rdfs_entry.label()[0:7] == "baseURI"
+        ):
+            entry_types.append("profile_iri_v2_4")
+        if rdfs_entry.label() == "shortName":
+            entry_types.append("short_profile_name_v2_4")
     return entry_types
 
 def _entry_types_version_3(rdfs_entry: RDFSEntry) -> list:
@@ -408,7 +436,7 @@ def _parse_rdf(input_dic, version):
         else:
             logger.info("Class {} for instance {} not found.".format(clarse, instance))
 
-    return {short_profile_name: classes_map}
+    return {short_profile_name: classes_map} # UNO RETUENS PROFIENAME
 
 
 # This function extracts all information needed for the creation of the python class files like the comments or the
@@ -447,12 +475,20 @@ def _write_python_files(elem_dict, langPack, outputPath, version):
         # extract comments
         if elem_dict[class_name].comment:
             class_details['class_comment'] = elem_dict[class_name].comment
+            class_details['wrapped_class_comment'] = wrap_and_clean(
+                elem_dict[class_name].comment, width=116, initial_indent='', subsequent_indent=' ' * 6
+            )
 
         for attribute in class_details['attributes']:
             if "comment" in attribute:
                 attribute["comment"] = attribute["comment"].replace('"', "`")
                 attribute["comment"] = attribute["comment"].replace("'", "`")
-
+                attribute["wrapped_comment"] = wrap_and_clean(
+                    attribute["comment"],
+                    width=114 - len(attribute["label"]),
+                    initial_indent="",
+                    subsequent_indent=" " * 6,
+                )
         _write_files(class_details, outputPath, version)
 
 def get_rid_of_hash(name):
@@ -496,7 +532,7 @@ def _write_files(class_details, outputPath, version):
             _dataType = attr['dataType']
         attr['class_name'] = format_class( _range, _dataType )
 
-    class_details['langPack'].run_template( outputPath, class_details )
+    class_details['langPack'].run_template( outputPath, class_details ) # WHAT IS TAHT ONE? DELTED IN UNO
 
 # Find multiple entries for the same attribute
 def _find_multiple_attributes(attributes_array):
@@ -657,10 +693,10 @@ def cim_generate(directory, outputPath, version, langPack):
 
     # work out the subclasses for each class by noting the reverse relationship
     for className in class_dict_with_origins:
-        superClassName = class_dict_with_origins[className].superClass();
+        superClassName = class_dict_with_origins[className].superClass()
         if superClassName != None:
-            if superClassName in  class_dict_with_origins:
-                superClass = class_dict_with_origins[superClassName];
+            if superClassName in class_dict_with_origins:
+                superClass = class_dict_with_origins[superClassName]
                 superClass.addSubClass(className)
             else:
                 print("No match for superClass in dict: :", superClassName)
@@ -671,6 +707,9 @@ def cim_generate(directory, outputPath, version, langPack):
     # get information for writing python files and write python files
     _write_python_files(class_dict_with_origins, langPack, outputPath, version)
 
-    logger.info('Elapsed Time: {}s\n\n'.format(time() - t0))
+    if "modernpython" in langPack.__name__:
+        langPack.resolve_headers(outputPath, version)
+    else:
+        langPack.resolve_headers(outputPath)
 
-
+    logger.info("Elapsed Time: {}s\n\n".format(time() - t0))

--- a/build.py
+++ b/build.py
@@ -1,17 +1,22 @@
-import CIMgen
-import os
 import argparse
 import importlib
+import os
+
+import CIMgen
 
 parser = argparse.ArgumentParser(description='Generate some CIM classes.')
 parser.add_argument('outdir', type=str, help='The output directory')
 parser.add_argument('schemadir', type=str, help='The schema directory')
 parser.add_argument('langdir', type=str, help='The langpack directory')
-parser.add_argument('--cgmes_version', type=str, choices=['cgmes_v2_4_13', 'cgmes_v2_4_15', 'cgmes_v3_0_0'], default='cgmes_v2_4_15', help='CGMES Version')
+parser.add_argument(
+    "--cgmes_version",
+    type=str,
+    choices=["cgmes_v2_4_13", "cgmes_v2_4_15", "cgmes_v3_0_0"],
+    default="cgmes_v2_4_15",
+    help="CGMES Version",
+)
 args = parser.parse_args()
 
 langPack = importlib.import_module(args.langdir + ".langPack")
 schema_path = os.path.join(os.getcwd(), args.schemadir)
 CIMgen.cim_generate(schema_path, args.outdir, args.cgmes_version, langPack)
-
-langPack.resolve_headers(args.outdir)

--- a/modernpython/Base.py
+++ b/modernpython/Base.py
@@ -1,0 +1,192 @@
+# We follow the CIM naming convention, not python.
+# pylint: disable=invalid-name
+
+"""
+Parent element of all CGMES elements
+"""
+import importlib
+from dataclasses import Field, fields
+from enum import Enum
+from functools import cache, cached_property
+from typing import Any, TypeAlias
+
+# Drop in dataclass replacement, allowing easier json dump and validation in the future.
+from pydantic.dataclasses import dataclass
+
+
+class Profile(Enum):
+    """
+    Enum containing all CGMES profiles and their export priority.
+    todo: enums are ordered, so we can have a short->long enum without explicit prio
+    """
+
+    EQ = 0
+    SSH = 1
+    TP = 2
+    SV = 3
+    DY = 4
+    OP = 5
+    SC = 6
+    GL = 7
+    # DI = 8 # Initially mentioned but does not seem used?
+    DL = 9
+    TPBD = 10
+    EQBD = 11
+
+    @cached_property
+    def long_name(self):
+        """From the short name, return the long name of the profile."""
+        return self._short_to_long()[self.name]
+
+    @classmethod
+    def from_long_name(cls, long_name):
+        """From the long name, return the short name of the profile."""
+        return cls[cls._long_to_short()[long_name]]
+
+    @classmethod
+    @cache
+    def _short_to_long(cls) -> dict[str, str]:
+        """Returns the long name from a short name"""
+        return {
+            "DL": "DiagramLayout",
+            # "DI": "DiagramLayout",
+            "DY": "Dynamics",
+            "EQ": "Equipment",
+            "EQBD": "EquipmentBoundary",  # Not too sure about that one
+            "GL": "GeographicalLocation",
+            "OP": "Operation",
+            "SC": "ShortCircuit",
+            "SV": "StateVariables",
+            "SSH": "SteadyStateHypothesis",
+            "TP": "Topology",
+            "TPBD": "TopologyBoundary",  # Not too sure about that one
+        }
+
+    @classmethod
+    @cache
+    def _long_to_short(cls) -> dict[str, str]:
+        """Returns the short name from a long name"""
+        return {_long: _short for _short, _long in cls._short_to_long().items()}
+
+
+class DataclassConfig:  # pylint: disable=too-few-public-methods
+    """
+    Used to configure pydantic dataclasses.
+
+    See doc at
+    https://docs.pydantic.dev/latest/usage/model_config/#options
+    """
+
+    # By default with pydantic extra arguments given to a dataclass are silently ignored.
+    # This matches the default behaviour by failing noisily.
+    extra = "forbid"
+
+
+# Default namespaces used by CGMES.
+NAMESPACES = {
+    "cim": "http://iec.ch/TC57/2013/CIM-schema-cim16#",
+    "entsoe": "http://entsoe.eu/CIM/SchemaExtension/3/1#",
+    "md": "http://iec.ch/TC57/61970-552/ModelDescription/1#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+}
+
+
+@dataclass(config=DataclassConfig)
+class Base:
+    """
+    Base Class for CIM.
+    """
+
+    @cached_property
+    def possible_profiles(self) -> set[Profile]:
+        raise NotImplementedError("Method not implemented because not relevant in Base.")
+
+    @staticmethod
+    def parse_json_as(attrs: dict[str, Any]) -> "Base":
+        """
+        Given a json, returns the original object.
+        """
+        subclass: str = attrs["__class__"]
+
+        # We want all attributes *except* __class__, and I do not want to modify
+        # the dict in params with del() or .pop()
+        data_attrs = {k: v for k, v in attrs.items() if k != "__class__"}
+
+        mod = importlib.import_module(f".{subclass}", package="pycgmes.resources")
+        # Works because the module and the class have the same name.
+        return getattr(mod, subclass)(**data_attrs)
+
+    def to_dict(self) -> dict[str, "CgmesAttributeTypes"]:
+        """
+        Returns the class as dict, with:
+        - only public attributes
+        - adding __class__ with the classname (for deserialisation)
+        """
+        attrs = {f.name: getattr(self, f.name) for f in fields(self)}
+        attrs["__class__"] = self.resource_name
+        return attrs
+
+    @cached_property
+    def resource_name(self) -> str:
+        """Returns the resource type."""
+        return self.__class__.__name__
+
+    def cgmes_attribute_names_in_profile(self, profile: Profile | None) -> set[Field]:
+        """
+        Returns all fields accross the parent tree which are in the profile in parameter.
+
+        Mostly useful during export to find all the attributes relevant to one profile only.
+
+        mRID will not be present as a resource attribute in the rdf, it will appear in the id of a resource,
+        so is skipped. For instance
+
+        <cim:ConnectivityNode rdf:ID="{Here the mRID}">
+            <cim:ConnectivityNode.ConnectivityNodeContainer>blah</cim:ConnectivityNode.ConnectivityNodeContainer>
+            {here the mRID will not appear}
+        </cim:ConnectivityNode>
+
+        If profile is None, returns all.
+        """
+        return {
+            f
+            for f in fields(self)
+            # The field is defined as a pydantic.Field, not a dataclass.field,
+            # so access to metadata is a tad different. Furthermore, mypy is confused by extra.
+            if (profile is None or profile in f.default.extra["in_profiles"])  # type: ignore[union-attr]
+            if f.name != "mRID"
+        }
+
+    def cgmes_attributes_in_profile(self, profile: Profile | None) -> dict[str, "CgmesAttributeTypes"]:
+        """
+        Returns all attribute values as a dict: fully qualified name => value.
+        Fully qualified names is in the form class_name.attribute_name, where class_name is the
+        (possibly parent) class where the attribute is defined.
+
+        This is used mostly in export, where the attributes need to be written in the form:
+        <cim:IdentifiedObject.name>3022308-EL-M01-145-SC3</cim:IdentifiedObject.name>
+        with thus the parent class included in the attribute name.
+        """
+        # What will be returned, has the qualname as key...
+        qual_attrs: dict[str, "CgmesAttributeTypes"] = {}
+        # .. but we check existence with the unqualified (short) name.
+        seen_attrs = set()
+
+        for parent in reversed(self.__class__.__mro__[:-1]):
+            for f in fields(parent):
+                shortname = f.name
+                qualname = f"{parent.__name__}.{shortname}"
+                if f not in self.cgmes_attribute_names_in_profile(profile) or shortname in seen_attrs:
+                    # Wrong profile or already found from a parent.
+                    continue
+                else:
+                    qual_attrs[qualname] = getattr(self, shortname)
+                    seen_attrs.add(shortname)
+
+        return qual_attrs
+
+    def __str__(self) -> str:
+        """Returns the string representation of this resource."""
+        return "\n".join([f"{k}={v}" for k, v in self.to_dict().items()])
+
+
+CgmesAttributeTypes: TypeAlias = str | int | float | Base | list | None

--- a/modernpython/Base.py
+++ b/modernpython/Base.py
@@ -84,10 +84,10 @@ class DataclassConfig:  # pylint: disable=too-few-public-methods
 
 # Default namespaces used by CGMES.
 NAMESPACES = {
-    "cim": "http://iec.ch/TC57/2013/CIM-schema-cim16#",
-    "entsoe": "http://entsoe.eu/CIM/SchemaExtension/3/1#",
-    "md": "http://iec.ch/TC57/61970-552/ModelDescription/1#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "cim": "http://iec.ch/TC57/2013/CIM-schema-cim16#",  # NOSONAR
+    "entsoe": "http://entsoe.eu/CIM/SchemaExtension/3/1#",  # NOSONAR
+    "md": "http://iec.ch/TC57/61970-552/ModelDescription/1#",  # NOSONAR
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",  # NOSONAR
 }
 
 

--- a/modernpython/Readme.md
+++ b/modernpython/Readme.md
@@ -1,0 +1,284 @@
+# Generates modern Python (3.9+)
+
+- [Generates modern Python (3.9+)](#generates-modern-python-39)
+  - [Description](#description)
+  - [Warning](#warning)
+  - [Examples](#examples)
+    - [Python](#python)
+    - [Modern Python](#modern-python)
+    - [Modern Python after black (formatting)](#modern-python-after-black-formatting)
+
+## Description
+
+It mostly uses dataclasses (pydantic one, to get data checks) and adds some attribute walking
+directly into the class. See for instance `cgmes_attributes_in_profile` in [Base.py](./Base.py).
+
+## Warning
+
+This is a major change compared to `python`, and makes it not compatible with cimexport. But by adding
+the attribute walk and adding the profiles as metadata from the attributes, it would make cimexport (or any
+other code using these classes) much simpler.
+
+## Examples
+
+Example of ACLineSegment.
+
+### Python
+
+```python
+from .Conductor import Conductor
+
+
+class ACLineSegment(Conductor):
+        '''
+        A wire or combination of wires, with consistent electrical characteristics, building a single electrical system, used to carry alternating current between points in the power system. For symmetrical, transposed 3ph lines, it is sufficient to use  attributes of the line segment, which describe impedances and admittances for the entire length of the segment.  Additionally impedances can be computed by using length and associated per length impedances. The BaseVoltage at the two ends of ACLineSegments in a Line shall have the same BaseVoltage.nominalVoltage. However, boundary lines  may have slightly different BaseVoltage.nominalVoltages and  variation is allowed. Larger voltage difference in general requires use of an equivalent branch.
+
+        :b0ch: Zero sequence shunt (charging) susceptance, uniformly distributed, of the entire line section. Default: 0.0
+        :bch: Positive sequence shunt (charging) susceptance, uniformly distributed, of the entire line section.  This value represents the full charging over the full length of the line. Default: 0.0
+        :g0ch: Zero sequence shunt (charging) conductance, uniformly distributed, of the entire line section. Default: 0.0
+        :gch: Positive sequence shunt (charging) conductance, uniformly distributed, of the entire line section. Default: 0.0
+        :r: Positive sequence series resistance of the entire line section. Default: 0.0
+        :r0: Zero sequence series resistance of the entire line section. Default: 0.0
+        :shortCircuitEndTemperature: Maximum permitted temperature at the end of SC for the calculation of minimum short-circuit currents. Used for short circuit data exchange according to IEC 60909 Default: 0.0
+        :x: Positive sequence series reactance of the entire line section. Default: 0.0
+        :x0: Zero sequence series reactance of the entire line section. Default: 0.0
+                '''
+
+        cgmesProfile = Conductor.cgmesProfile
+
+        possibleProfileList = {'class': [cgmesProfile.EQ.value, ],
+                                                'b0ch': [cgmesProfile.EQ.value, ],
+                                                'bch': [cgmesProfile.EQ.value, ],
+                                                'g0ch': [cgmesProfile.EQ.value, ],
+                                                'gch': [cgmesProfile.EQ.value, ],
+                                                'r': [cgmesProfile.EQ.value, ],
+                                                'r0': [cgmesProfile.EQ.value, ],
+                                                'shortCircuitEndTemperature': [cgmesProfile.EQ.value, ],
+                                                'x': [cgmesProfile.EQ.value, ],
+                                                'x0': [cgmesProfile.EQ.value, ],
+                                                 }
+
+        serializationProfile = {}
+
+        __doc__ += '\n Documentation of parent class Conductor: \n' + Conductor.__doc__
+
+        def __init__(self, b0ch = 0.0, bch = 0.0, g0ch = 0.0, gch = 0.0, r = 0.0, r0 = 0.0, shortCircuitEndTemperature = 0.0, x = 0.0, x0 = 0.0,  *args, **kw_args):
+                super().__init__(*args, **kw_args)
+
+                self.b0ch = b0ch
+                self.bch = bch
+                self.g0ch = g0ch
+                self.gch = gch
+                self.r = r
+                self.r0 = r0
+                self.shortCircuitEndTemperature = shortCircuitEndTemperature
+                self.x = x
+                self.x0 = x0
+
+        def __str__(self):
+                str = 'class=ACLineSegment\n'
+                attributes = self.__dict__
+                for key in attributes.keys():
+                        str = str + key + '={}\n'.format(attributes[key])
+                return str
+```
+
+### Modern Python
+
+```python
+"""
+Generated from the CGMES 3 files via cimgen: https://github.com/sogno-platform/cimgen
+"""
+
+from functools import cached_property
+from typing import Optional
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+from .Base import DataclassConfig, Profile
+from .Conductor import Conductor
+
+@dataclass(config=DataclassConfig)
+class ACLineSegment(Conductor):
+    """
+    A wire or combination of wires, with consistent electrical characteristics, building a single electrical system,
+      used to carry alternating current between points in the power system. For symmetrical, transposed three phase
+      lines, it is sufficient to use attributes of the line segment, which describe impedances and admittances for
+      the entire length of the segment.  Additionally impedances can be computed by using length and associated per
+      length impedances. The BaseVoltage at the two ends of ACLineSegments in a Line shall have the same
+      BaseVoltage.nominalVoltage. However, boundary lines may have slightly different BaseVoltage.nominalVoltages
+      and variation is allowed. Larger voltage difference in general requires use of an equivalent branch.
+
+    bch: Positive sequence shunt (charging) susceptance, uniformly distributed, of the entire line section.  This value
+      represents the full charging over the full length of the line.
+    gch: Positive sequence shunt (charging) conductance, uniformly distributed, of the entire line section.
+    r: Positive sequence series resistance of the entire line section.
+    x: Positive sequence series reactance of the entire line section.
+    Clamp: The clamps connected to the line segment.
+    Cut: Cuts applied to the line segment.
+    b0ch: Zero sequence shunt (charging) susceptance, uniformly distributed, of the entire line section.
+    g0ch: Zero sequence shunt (charging) conductance, uniformly distributed, of the entire line section.
+    r0: Zero sequence series resistance of the entire line section.
+    shortCircuitEndTemperature: Maximum permitted temperature at the end of SC for the calculation of minimum short-
+      circuit currents. Used for short circuit data exchange according to IEC 60909.
+    x0: Zero sequence series reactance of the entire line section.
+    """
+
+    bch : float = Field(default=0.0, in_profiles = [Profile.EQ, ])
+
+    gch : float = Field(default=0.0, in_profiles = [Profile.EQ, ])
+
+    r : float = Field(default=0.0, in_profiles = [Profile.EQ, ])
+
+    x : float = Field(default=0.0, in_profiles = [Profile.EQ, ])
+
+    # *Association not used*
+    # Type M:0..n in CIM  # pylint: disable-next=line-too-long
+    # Clamp : list = Field(default_factory=list, in_profiles = [Profile.EQ, ]) # noqa: E501
+
+    # *Association not used*
+    # Type M:0..n in CIM  # pylint: disable-next=line-too-long
+    # Cut : list = Field(default_factory=list, in_profiles = [Profile.EQ, ]) # noqa: E501
+
+    b0ch : float = Field(default=0.0, in_profiles = [Profile.SC, ])
+
+    g0ch : float = Field(default=0.0, in_profiles = [Profile.SC, ])
+
+    r0 : float = Field(default=0.0, in_profiles = [Profile.SC, ])
+
+    shortCircuitEndTemperature : float = Field(default=0.0, in_profiles = [Profile.SC, ])
+
+    x0 : float = Field(default=0.0, in_profiles = [Profile.SC, ])
+
+
+
+    @cached_property
+    def possible_profiles(self)->set[Profile]:
+        """
+        A resource can be used by multiple profiles. This is the set of profiles
+        where this element can be found.
+        """
+        return { Profile.EQ, Profile.SC,  }
+```
+
+### Modern Python after black (formatting)
+
+```python
+"""
+Generated from the CGMES 3 files via cimgen: https://github.com/sogno-platform/cimgen
+"""
+
+from functools import cached_property
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+from .Base import DataclassConfig, Profile
+from .Conductor import Conductor
+
+
+@dataclass(config=DataclassConfig)
+class ACLineSegment(Conductor):
+    """
+    A wire or combination of wires, with consistent electrical characteristics, building a single electrical system,
+      used to carry alternating current between points in the power system. For symmetrical, transposed three phase
+      lines, it is sufficient to use attributes of the line segment, which describe impedances and admittances for
+      the entire length of the segment.  Additionally impedances can be computed by using length and associated per
+      length impedances. The BaseVoltage at the two ends of ACLineSegments in a Line shall have the same
+      BaseVoltage.nominalVoltage. However, boundary lines may have slightly different BaseVoltage.nominalVoltages
+      and variation is allowed. Larger voltage difference in general requires use of an equivalent branch.
+
+    bch: Positive sequence shunt (charging) susceptance, uniformly distributed, of the entire line section.  This value
+      represents the full charging over the full length of the line.
+    gch: Positive sequence shunt (charging) conductance, uniformly distributed, of the entire line section.
+    r: Positive sequence series resistance of the entire line section.
+    x: Positive sequence series reactance of the entire line section.
+    Clamp: The clamps connected to the line segment.
+    Cut: Cuts applied to the line segment.
+    b0ch: Zero sequence shunt (charging) susceptance, uniformly distributed, of the entire line section.
+    g0ch: Zero sequence shunt (charging) conductance, uniformly distributed, of the entire line section.
+    r0: Zero sequence series resistance of the entire line section.
+    shortCircuitEndTemperature: Maximum permitted temperature at the end of SC for the calculation of minimum short-
+      circuit currents. Used for short circuit data exchange according to IEC 60909.
+    x0: Zero sequence series reactance of the entire line section.
+    """
+
+    bch: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.EQ,
+        ],
+    )
+
+    gch: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.EQ,
+        ],
+    )
+
+    r: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.EQ,
+        ],
+    )
+
+    x: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.EQ,
+        ],
+    )
+
+    # *Association not used*
+    # Type M:0..n in CIM  # pylint: disable-next=line-too-long
+    # Clamp : list = Field(default_factory=list, in_profiles = [Profile.EQ, ])
+
+    # *Association not used*
+    # Type M:0..n in CIM  # pylint: disable-next=line-too-long
+    # Cut : list = Field(default_factory=list, in_profiles = [Profile.EQ, ])
+
+    b0ch: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.SC,
+        ],
+    )
+
+    g0ch: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.SC,
+        ],
+    )
+
+    r0: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.SC,
+        ],
+    )
+
+    shortCircuitEndTemperature: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.SC,
+        ],
+    )
+
+    x0: float = Field(
+        default=0.0,
+        in_profiles=[
+            Profile.SC,
+        ],
+    )
+
+    @cached_property
+    def possible_profiles(self) -> set[Profile]:
+        """
+        A resource can be used by multiple profiles. This is the set of profiles
+        where this element can be found.
+        """
+        return {
+            Profile.EQ,
+            Profile.SC,
+        }
+```

--- a/modernpython/__init__.py
+++ b/modernpython/__init__.py
@@ -1,0 +1,1 @@
+import modernpython.langPack

--- a/modernpython/langPack.py
+++ b/modernpython/langPack.py
@@ -1,0 +1,156 @@
+import glob
+import logging
+import os
+import re
+import sys
+import textwrap
+from pathlib import Path
+
+import chevron
+
+logger = logging.getLogger(__name__)
+
+
+# This makes sure we have somewhere to write the classes, and
+# creates a couple of files the python implementation needs.
+# cgmes_profile_info details which uri belongs in each profile.
+# We don't use that here because we aren't creating the header
+# data for the separate profiles.
+def setup(version_path, cgmes_profile_info):
+    if not os.path.exists(version_path):
+        os.makedirs(version_path)
+        _create_init(version_path)
+        _create_base(version_path)
+
+
+def location(version):
+    return "cimpy." + version + ".Base"
+
+
+base = {"base_class": "Base", "class_location": location}
+
+template_files = [{"filename": "cimpy_class_template.mustache", "ext": ".py"}]
+
+
+def get_class_location(class_name, class_map, version):
+    # Check if the current class has a parent class
+    if class_map[class_name].superClass():
+        if class_map[class_name].superClass() in class_map:
+            return "cimpy." + version + "." + class_map[class_name].superClass()
+        elif class_map[class_name].superClass() == "Base" or class_map[class_name].superClass() == None:
+            return location(version)
+    else:
+        return location(version)
+
+
+partials = {}
+
+
+# called by chevron, text contains the label {{dataType}}, which is evaluated by the renderer (see class template)
+def _set_default(text, render):
+    return _get_type_and_default(text, render)[1]
+
+
+def _set_type(text, render):
+    return _get_type_and_default(text, render)[0]
+
+
+def _get_type_and_default(text, renderer) -> tuple[str, str]:
+    result = renderer(text)
+    # the field {{dataType}} either contains the multiplicity of an attribute if it is a reference or otherwise the
+    # datatype of the attribute. If no datatype is set and there is also no multiplicity entry for an attribute, the
+    # default value is set to None. The multiplicity is set for all attributes, but the datatype is only set for basic
+    # data types. If the data type entry for an attribute is missing, the attribute contains a reference and therefore
+    # the default value is either None or [] depending on the multiplicity. See also write_python_files
+    # The default will be copied as-is, hence the possibility to have default or default_factory.
+    if result in ["M:1", "M:0..1", "M:1..1", ""]:
+        return ("Optional[str]", "default=None")
+    elif result in ["M:0..n", "M:1..n"] or "M:" in result:
+        return ("list", "default_factory=list")
+
+    result = result.split("#")[1]
+    if result in ["integer", "Integer", "Seconds"]:
+        return ("int", "default=0")
+    elif result in ["String", "DateTime", "Date"]:
+        return ("str", 'default=""')
+    elif result == "Boolean":
+        return ("bool", "default=False")
+    else:
+        # everything else should be a float
+        return ("float", "default=0.0")
+
+
+def set_enum_classes(new_enum_classes):
+    return
+
+
+def set_float_classes(new_float_classes):
+    return
+
+
+def run_template(version_path, class_details):
+    for template_info in template_files:
+        class_file = os.path.join(version_path, class_details["class_name"] + template_info["ext"])
+        if not os.path.exists(class_file):
+            with open(class_file, "w", encoding="utf-8") as file:
+                template_path = os.path.join(os.getcwd(), "modernpython/templates", template_info["filename"])
+                class_details["setDefault"] = _set_default
+                class_details["setType"] = _set_type
+                with open(template_path, encoding="utf-8") as f:
+                    args = {
+                        "data": class_details,
+                        "template": f,
+                        "partials_dict": partials,
+                    }
+                    output = chevron.render(**args)
+                file.write(output)
+
+
+def _create_init(path):
+    init_file = path + "/__init__.py"
+
+    with open(init_file, "w", encoding="utf-8") as init:
+        init.write("# pylint: disable=too-many-lines,missing-module-docstring\n")
+
+
+# creates the Base class file, all classes inherit from this class
+def _create_base(path):
+    # TODO: Check export priority of OP en SC, see Profile class
+    base_path = path + "/Base.py"
+    with open(Path(__file__).parent / "Base.py", encoding="utf-8") as src, open(
+        base_path, "w", encoding="utf-8"
+    ) as dst:
+        dst.write(src.read())
+
+
+def resolve_headers(dest: str, version: str):
+    """Add all classes in __init__.py"""
+    if match := re.search(r"(?P<num>\d+_\d+_\d+)", version):
+        version_number = match.group("num").replace("_", ".")
+    else:
+        raise ValueError(f"Cannot parse {version} to extract a number.")
+
+    dest = Path(dest)
+    with open(dest / "__init__.py", "a", encoding="utf-8") as header_file:
+        _all = []
+        for include_name in sorted(dest.glob("*.py")):
+            stem = include_name.stem
+            if stem == "__init__":
+                continue
+            _all.append(stem)
+            header_file.write(f"from .{stem} import {stem}\n")
+
+        header_file.write(f"CGMES_VERSION='{version_number}'\n")
+        _all.append("CGMES_VERSION")
+
+        header_file.write(
+            "\n".join(
+                [
+                    "# This is not needed per se, but by referencing all imports",
+                    "# this prevents a potential autoflake from cleaning up the whole file.",
+                    "# FYA, if __all__ is present, only what's in there will be import with a import *",
+                    "",
+                ]
+            )
+        )
+        header_file.write(f"__all__={_all}")

--- a/modernpython/langPack.py
+++ b/modernpython/langPack.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 # cgmes_profile_info details which uri belongs in each profile.
 # We don't use that here because we aren't creating the header
 # data for the separate profiles.
-def setup(version_path, cgmes_profile_info):
+def setup(version_path, cgmes_profile_info): # NOSONAR
     if not os.path.exists(version_path):
         os.makedirs(version_path)
         _create_init(version_path)
@@ -125,7 +125,7 @@ def _create_base(path):
 
 def resolve_headers(dest: str, version: str):
     """Add all classes in __init__.py"""
-    if match := re.search(r"(?P<num>\d+_\d+_\d+)", version):
+    if match := re.search(r"(?P<num>\d+_\d+_\d+)", version): # NOSONAR
         version_number = match.group("num").replace("_", ".")
     else:
         raise ValueError(f"Cannot parse {version} to extract a number.")

--- a/modernpython/templates/cimpy_class_template.mustache
+++ b/modernpython/templates/cimpy_class_template.mustache
@@ -1,0 +1,39 @@
+"""
+Generated from the CGMES 3 files via cimgen: https://github.com/Alliander/uno-cimgen/
+"""
+
+from functools import cached_property
+from typing import Optional
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+from .Base import DataclassConfig, Profile
+from .{{sub_class_of}} import {{sub_class_of}}
+
+@dataclass(config=DataclassConfig)
+class {{class_name}}({{sub_class_of}}):
+    """
+    {{{wrapped_class_comment}}}
+
+    {{#attributes}}
+    {{label}}: {{{wrapped_comment}}}
+    {{/attributes}}
+    """
+
+    {{#attributes}}
+    {{^isAssociationUsed}}# *Association not used*
+    # Type {{dataType}} in CIM  # pylint: disable-next=line-too-long
+    # {{/isAssociationUsed}}{{label}} : {{#setType}}{{dataType}}{{/setType}} = Field({{#setDefault}}{{dataType}}{{/setDefault}}, in_profiles = [{{#attr_origin}}Profile.{{origin}}, {{/attr_origin}}]) {{^isAssociationUsed}}# noqa: E501{{/isAssociationUsed}}
+
+    {{/attributes}}
+    {{^attributes}}
+    # No attributes defined for this class.
+    {{/attributes}}
+
+
+    @cached_property
+    def possible_profiles(self)->set[Profile]:
+        """
+        A resource can be used by multiple profiles. This is the set of profiles
+        where this element can be found.
+        """
+        return { {{#class_origin}}Profile.{{origin}}, {{/class_origin}} }

--- a/modernpython/templates/cimpy_class_template.mustache
+++ b/modernpython/templates/cimpy_class_template.mustache
@@ -1,5 +1,5 @@
 """
-Generated from the CGMES 3 files via cimgen: https://github.com/Alliander/uno-cimgen/
+Generated from the CGMES 3 files via cimgen: https://github.com/sogno-platform/cimgen
 """
 
 from functools import cached_property


### PR DESCRIPTION
Adding Python 3.9+ langpack, with pydantic dataclasses.

Those classes cannot be used directly with cimpy, but they do simplify quite a lot of coding. The class tree crawling is built into Base, profiles to which an attribute belongs are added to the attribute definition itself, json dump/parsing is built in. 

Sonarcloud complains about code smells - those are logical, but fixing those would cause discrepancy with the style of the rest of the code, so I leave them as is for now. If that's not the best option, let me know. 