### PR TITLE
use float as default for Seconds

### DIFF
--- a/modernpython/langPack.py
+++ b/modernpython/langPack.py
@@ -64,7 +64,7 @@ def _get_type_and_default(text, renderer) -> tuple[str, str]:
         return ("list", "default_factory=list")
 
     result = result.split("#")[1]
-    if result in ["integer", "Integer", "Seconds"]:
+    if result in ["integer", "Integer"]:
         return ("int", "default=0")
     elif result in ["String", "DateTime", "Date"]:
         return ("str", 'default=""')

--- a/python/langPack.py
+++ b/python/langPack.py
@@ -53,7 +53,7 @@ def _set_default(text, render):
         return '"list"'
 
     result = result.split('#')[1]
-    if result in ['integer', 'Integer', 'Seconds' ]:
+    if result in ['integer', 'Integer']:
         return '0'
     elif result in ['String', 'DateTime', 'Date']:
         return "''"


### PR DESCRIPTION
Fixing #15. This issue is affecting both python versions.