### PR TITLE
Fix class and attribute types

### DIFF
--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -2,7 +2,6 @@ import logging
 import os
 import textwrap
 import warnings
-import re
 from time import time
 
 import xmltodict

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -772,7 +772,7 @@ def _get_attribute_type(attribute: dict, class_infos: CIMComponentDefinition) ->
         attribute_type = "primitive"
     elif class_infos.is_an_enum_class():
         attribute_type = "enum"
-    elif attribute.get("multiplicity") in ("M:0..n", "M:1..n", "M:2..n"):
+    elif attribute.get("multiplicity") in ("M:0..n", "M:0..2", "M:1..n", "M:2..n"):
         attribute_type = "list"
     return attribute_type
 

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -258,7 +258,7 @@ class CIMComponentDefinition:
         return False
 
     def is_a_float_class(self):
-        if self.about == "Float":
+        if self.about in ("Float", "Decimal"):
             return True
         simple_float = False
         for attr in self.attribute_list:

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -512,8 +512,7 @@ def _write_python_files(elem_dict, lang_pack, output_path, version):
                     subsequent_indent=" " * 6,
                 )
             attribute_class = _get_attribute_class(attribute)
-            is_an_enum_class = attribute_class in elem_dict and elem_dict[attribute_class].is_an_enum_class()
-            attribute_type = _get_attribute_type(attribute, is_an_enum_class)
+            attribute_type = _get_attribute_type(attribute, elem_dict[attribute_class])
             attribute["is_class_attribute"] = _get_bool_string(attribute_type == "class")
             attribute["is_enum_attribute"] = _get_bool_string(attribute_type == "enum")
             attribute["is_list_attribute"] = _get_bool_string(attribute_type == "list")
@@ -842,26 +841,17 @@ def _get_attribute_class(attribute: dict) -> str:
     return _get_rid_of_hash(name)
 
 
-def _get_attribute_type(attribute: dict, is_an_enum_class: bool) -> str:
+def _get_attribute_type(attribute: dict, class_infos: CIMComponentDefinition) -> str:
     """Get the type of an attribute: "class", "enum", "list", or "primitive".
 
     :param attribute:        Dictionary with information about an attribute of a class.
-    :param is_an_enum_class: Is this attribute an enumation?
+    :param class_infos:      Information about the attribute class.
     :return:                 Type of the attribute.
     """
-    so_far_not_primitive = _get_attribute_class(attribute) in (
-        "Date",
-        "DateTime",
-        "MonthDay",
-        "Status",
-        "StreetAddress",
-        "StreetDetail",
-        "TownDetail",
-    )
     attribute_type = "class"
-    if "dataType" in attribute and not so_far_not_primitive:
+    if class_infos.is_a_primitive_class() or class_infos.is_a_float_class():
         attribute_type = "primitive"
-    elif is_an_enum_class:
+    elif class_infos.is_an_enum_class():
         attribute_type = "enum"
     elif attribute.get("multiplicity") in ("M:0..n", "M:1..n", "M:2..n"):
         attribute_type = "list"

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -8,6 +8,7 @@ from time import time
 import xmltodict
 from bs4 import BeautifulSoup
 
+logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
@@ -249,6 +250,7 @@ class CIMComponentDefinition:
     def setSubClasses(self, classes):
         self.subclasses = classes
 
+    @staticmethod
     def _simple_float_attribute(attr):
         if "dataType" in attr:
             return attr["label"] == "value" and attr["dataType"] == "#Float"
@@ -856,7 +858,7 @@ def _get_attribute_type(attribute: dict, is_an_enum_class: bool) -> str:
         attribute_type = "primitive"
     elif is_an_enum_class:
         attribute_type = "enum"
-    elif attribute.get("multiplicity") in ("M:0..n", "M:1..n"):
+    elif attribute.get("multiplicity") in ("M:0..n", "M:1..n", "M:2..n"):
         attribute_type = "list"
     return attribute_type
 

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -211,6 +211,7 @@ class CIMComponentDefinition:
         self.origin_list = []
         self.super = rdfsEntry.subClassOf()
         self.subclasses = []
+        self.stereotype = rdfsEntry.stereotype()
 
     def attributes(self):
         return self.attribute_list
@@ -281,6 +282,9 @@ class CIMComponentDefinition:
             if not candidate_array[key]:
                 return False
         return True
+
+    def is_a_primitive_class(self):
+        return self.stereotype == "Primitive"
 
 
 def get_profile_name(descriptions):
@@ -382,8 +386,7 @@ def _add_class(classes_map, rdfs_entry):
     """
     if rdfs_entry.label() in classes_map:
         logger.error("Class {} already exists".format(rdfs_entry.label()))
-    if rdfs_entry.label() != "String":
-        classes_map[rdfs_entry.label()] = CIMComponentDefinition(rdfs_entry)
+    classes_map[rdfs_entry.label()] = CIMComponentDefinition(rdfs_entry)
 
 
 def _add_profile_to_packages(profile_name, short_profile_name, profile_uri_list):
@@ -481,6 +484,7 @@ def _write_python_files(elem_dict, lang_pack, output_path, version):
             "enum_instances": elem_dict[class_name].enum_instances(),
             "is_an_enum_class": elem_dict[class_name].is_an_enum_class(),
             "is_a_float_class": elem_dict[class_name].is_a_float_class(),
+            "is_a_primitive_class": elem_dict[class_name].is_a_primitive_class(),
             "langPack": lang_pack,
             "sub_class_of": elem_dict[class_name].superClass(),
             "sub_classes": elem_dict[class_name].subClasses(),
@@ -514,6 +518,7 @@ def _write_python_files(elem_dict, lang_pack, output_path, version):
             attribute["is_enum_attribute"] = _get_bool_string(attribute_type == "enum")
             attribute["is_list_attribute"] = _get_bool_string(attribute_type == "list")
             attribute["is_primitive_attribute"] = _get_bool_string(attribute_type == "primitive")
+            attribute["is_primitive_float_attribute"] = _get_bool_string(elem_dict[attribute_class].is_a_float_class())
             attribute["attribute_class"] = attribute_class
 
         class_details["attributes"].sort(key=lambda d: d["label"])

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -63,11 +63,7 @@ def run_template(output_path, class_details):
     else:
         templates = template_files
 
-    if (
-        class_details["class_name"] == "Integer"
-        or class_details["class_name"] == "Boolean"
-        or class_details["class_name"] == "Date"
-    ):
+    if class_details["class_name"] in ("String", "Integer", "Boolean", "Date"):
         # These classes are defined already
         # We have to implement operators for them
         return

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -56,7 +56,7 @@ partials = {
 # This is the function that runs the template.
 def run_template(output_path, class_details):
 
-    if class_details["is_a_float_class"]:
+    if class_details["is_a_datatype_class"] or class_details["class_name"] in ("Float", "Decimal"):
         templates = float_template_files
     elif class_details["is_an_enum_class"]:
         templates = enum_template_files
@@ -104,7 +104,7 @@ def label(text, render):
 def insert_assign_fn(text, render):
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
-    if not (attribute_json["is_primitive_attribute"] or attribute_json["is_enum_attribute"]):
+    if not _attribute_is_primitive_or_datatype_or_enum(attribute_json):
         return ""
     label = attribute_json["label"]
     class_name = attribute_json["domain"]
@@ -124,7 +124,7 @@ def insert_assign_fn(text, render):
 def insert_class_assign_fn(text, render):
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
-    if attribute_json["is_primitive_attribute"] or attribute_json["is_enum_attribute"]:
+    if _attribute_is_primitive_or_datatype_or_enum(attribute_json):
         return ""
     label = attribute_json["label"]
     class_name = attribute_json["domain"]
@@ -165,7 +165,7 @@ def create_class_assign(text, render):
     attribute_json = eval(attribute_txt)
     assign = ""
     attribute_class = attribute_json["attribute_class"]
-    if attribute_json["is_primitive_attribute"] or attribute_json["is_enum_attribute"]:
+    if _attribute_is_primitive_or_datatype_or_enum(attribute_json):
         return ""
     if attribute_json["is_list_attribute"]:
         assign = (
@@ -229,7 +229,7 @@ def create_assign(text, render):
     attribute_json = eval(attribute_txt)
     assign = ""
     _class = attribute_json["attribute_class"]
-    if not (attribute_json["is_primitive_attribute"] or attribute_json["is_enum_attribute"]):
+    if not _attribute_is_primitive_or_datatype_or_enum(attribute_json):
         return ""
     label_without_keyword = attribute_json["label"]
     if label_without_keyword == "switch":
@@ -282,7 +282,7 @@ def attribute_decl(text, render):
 
 def _attribute_decl(attribute):
     _class = attribute["attribute_class"]
-    if attribute["is_primitive_attribute"] or attribute["is_enum_attribute"]:
+    if _attribute_is_primitive_or_datatype_or_enum(attribute):
         return "CIMPP::" + _class
     if attribute["is_list_attribute"]:
         return "std::list<CIMPP::" + _class + "*>"
@@ -299,7 +299,7 @@ def _create_attribute_includes(text, render):
     if jsonStringNoHtmlEsc is not None and jsonStringNoHtmlEsc != "":
         attributes = json.loads(jsonStringNoHtmlEsc)
         for attribute in attributes:
-            if attribute["is_primitive_attribute"] or attribute["is_enum_attribute"]:
+            if _attribute_is_primitive_or_datatype_or_enum(attribute):
                 unique[attribute["attribute_class"]] = True
     for clarse in unique:
         include_string += '\n#include "' + clarse + '.hpp"'
@@ -347,6 +347,14 @@ def set_default(dataType):
         return "0.0"
     else:
         return "nullptr"
+
+
+def _attribute_is_primitive_or_datatype_or_enum(attribute: dict) -> bool:
+    return _attribute_is_primitive_or_datatype(attribute) or attribute["is_enum_attribute"]
+
+
+def _attribute_is_primitive_or_datatype(attribute: dict) -> bool:
+    return attribute["is_primitive_attribute"] or attribute["is_datatype_attribute"]
 
 
 # The code below this line is used after the main cim_generate phase to generate

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -47,10 +47,10 @@ def run_template(output_path, class_details):
 
     class_details["primitives"] = []
     for attr in class_details["attributes"]:
-        if attr["is_primitive_attribute"] or attr["is_enum_attribute"]:
+        if _attribute_is_primitive_or_datatype_or_enum(attr):
             class_details["primitives"].append(attr)
 
-    if class_details["is_a_float_class"]:
+    if class_details["is_a_datatype_class"] or class_details["class_name"] in ("Float", "Decimal"):
         templates = float_template_files
     elif class_details["is_an_enum_class"]:
         templates = enum_template_files
@@ -103,7 +103,7 @@ def create_assign(text, render):
     attribute_json = eval(attribute_txt)
     assign = ""
     _class = attribute_json["attribute_class"]
-    if not (attribute_json["is_primitive_attribute"] or attribute_json["is_enum_attribute"]):
+    if not _attribute_is_primitive_or_datatype_or_enum(attribute_json):
         return ""
     label_without_keyword = attribute_json["label"]
     if label_without_keyword == "switch":
@@ -140,7 +140,7 @@ def attribute_decl(text, render):
 
 def _attribute_decl(attribute):
     _class = attribute["attribute_class"]
-    if attribute["is_primitive_attribute"] or attribute["is_enum_attribute"]:
+    if _attribute_is_primitive_or_datatype_or_enum(attribute):
         return _class
     if attribute["is_list_attribute"]:
         return "List<" + _class + ">"
@@ -157,7 +157,7 @@ def _create_attribute_includes(text, render):
     if jsonStringNoHtmlEsc is not None and jsonStringNoHtmlEsc != "":
         attributes = json.loads(jsonStringNoHtmlEsc)
         for attribute in attributes:
-            if attribute["is_primitive_attribute"] or attribute["is_enum_attribute"]:
+            if _attribute_is_primitive_or_datatype_or_enum(attribute):
                 unique[attribute["attribute_class"]] = True
     for clarse in unique:
         if clarse != "String":
@@ -204,6 +204,10 @@ def set_default(dataType):
         return "false"
     else:
         return "nullptr"
+
+
+def _attribute_is_primitive_or_datatype_or_enum(attribute: dict) -> bool:
+    return attribute["is_primitive_attribute"] or attribute["is_datatype_attribute"] or attribute["is_enum_attribute"]
 
 
 # The code below this line is used after the main cim_generate phase to generate

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -57,11 +57,7 @@ def run_template(output_path, class_details):
     else:
         templates = template_files
 
-    if (
-        class_details["class_name"] == "Integer"
-        or class_details["class_name"] == "Boolean"
-        or class_details["class_name"] == "Date"
-    ):
+    if class_details["class_name"] in ("String", "Integer", "Boolean", "Date"):
         # These classes are defined already
         # We have to implement operators for them
         return

--- a/cimgen/languages/javascript/lang_pack.py
+++ b/cimgen/languages/javascript/lang_pack.py
@@ -102,6 +102,8 @@ def select_primitive_render_function(class_details):
 
 # This is the function that runs the template.
 def run_template(output_path, class_details):
+    if class_details["class_name"] == "String":
+        return
 
     for index, attribute in enumerate(class_details["attributes"]):
         if not attribute["is_used"]:

--- a/cimgen/languages/javascript/lang_pack.py
+++ b/cimgen/languages/javascript/lang_pack.py
@@ -76,7 +76,9 @@ aggregateRenderer = {
 def select_primitive_render_function(class_details):
     class_name = class_details["class_name"]
     render = ""
-    if class_details["is_a_float_class"]:
+    if class_details["is_a_datatype_class"]:
+        render = aggregateRenderer["renderFloat"]
+    elif class_name in ("Float", "Decimal"):
         render = aggregateRenderer["renderFloat"]
     elif class_name == "String":
         render = aggregateRenderer["renderString"]
@@ -86,9 +88,6 @@ def select_primitive_render_function(class_details):
         # TODO: Implementation Required!
         render = aggregateRenderer["renderString"]
     elif class_name == "DateTime":
-        # TODO: Implementation Required!
-        render = aggregateRenderer["renderString"]
-    elif class_name == "Decimal":
         # TODO: Implementation Required!
         render = aggregateRenderer["renderString"]
     elif class_name == "Integer":
@@ -158,8 +157,7 @@ def _create_cgmes_profile(output_path: str, profile_details: list, cim_namespace
 
 
 def _get_class_type(class_details):
-    class_name = class_details["class_name"]
-    if class_details["is_a_float_class"] or class_name in ("String", "Boolean", "Integer"):
+    if class_details["is_a_primitive_class"] or class_details["is_a_datatype_class"]:
         return "primitive"
     if class_details["is_an_enum_class"]:
         return "enum"

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -63,7 +63,9 @@ def _get_type_and_default(text, render) -> tuple[str, str]:
         return ("Optional[str]", "default=None")
     elif attribute_json["is_list_attribute"]:
         return ("list", "default_factory=list")
-    elif attribute_json["is_primitive_float_attribute"]:
+    elif attribute_json["is_datatype_attribute"]:
+        return ("float", "default=0.0")
+    elif attribute_json["attribute_class"] in ("Float", "Decimal"):
         return ("float", "default=0.0")
     elif attribute_json["attribute_class"] == "Integer":
         return ("int", "default=0")
@@ -75,7 +77,7 @@ def _get_type_and_default(text, render) -> tuple[str, str]:
 
 
 def run_template(output_path, class_details):
-    if class_details["is_a_primitive_class"] or class_details["is_a_float_class"]:
+    if class_details["is_a_primitive_class"] or class_details["is_a_datatype_class"]:
         return
     for template_info in template_files:
         resource_file = Path(

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -47,7 +47,7 @@ def get_class_location(class_name, class_map, version):  # NOSONAR
 partials = {}
 
 
-# called by chevron, text contains the label {{dataType}}, which is evaluated by the renderer (see class template)
+# called by chevron, text contains the attribute infos, which are evaluated by the renderer (see class template)
 def _set_default(text, render):
     return _get_type_and_default(text, render)[1]
 
@@ -56,29 +56,22 @@ def _set_type(text, render):
     return _get_type_and_default(text, render)[0]
 
 
-def _get_type_and_default(text, renderer) -> tuple[str, str]:
-    result = renderer(text)
-    # the field {{dataType}} either contains the multiplicity of an attribute if it is a reference or otherwise the
-    # datatype of the attribute. If no datatype is set and there is also no multiplicity entry for an attribute, the
-    # default value is set to None. The multiplicity is set for all attributes, but the datatype is only set for basic
-    # data types. If the data type entry for an attribute is missing, the attribute contains a reference and therefore
-    # the default value is either None or [] depending on the multiplicity. See also write_python_files
-    # The default will be copied as-is, hence the possibility to have default or default_factory.
-    if result in ["M:1", "M:0..1", "M:1..1", ""]:
+def _get_type_and_default(text, render) -> tuple[str, str]:
+    attribute_txt = render(text)
+    attribute_json = eval(attribute_txt)
+    if attribute_json["is_class_attribute"]:
         return ("Optional[str]", "default=None")
-    elif result in ["M:0..n", "M:1..n"] or "M:" in result:
+    elif attribute_json["is_list_attribute"]:
         return ("list", "default_factory=list")
-
-    result = result.split("#")[1]
-    if result in ["integer", "Integer"]:
+    elif attribute_json["is_primitive_float_attribute"]:
+        return ("float", "default=0.0")
+    elif attribute_json["attribute_class"] == "Integer":
         return ("int", "default=0")
-    elif result in ["String", "DateTime", "Date"]:
-        return ("str", 'default=""')
-    elif result == "Boolean":
+    elif attribute_json["attribute_class"] == "Boolean":
         return ("bool", "default=False")
     else:
-        # everything else should be a float
-        return ("float", "default=0.0")
+        # everything else should be a string
+        return ("str", 'default=""')
 
 
 def run_template(output_path, class_details):

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -75,7 +75,7 @@ def _get_type_and_default(text, render) -> tuple[str, str]:
 
 
 def run_template(output_path, class_details):
-    if class_details["class_name"] == "String":
+    if class_details["is_a_primitive_class"] or class_details["is_a_float_class"]:
         return
     for template_info in template_files:
         resource_file = Path(

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -82,6 +82,8 @@ def _get_type_and_default(text, renderer) -> tuple[str, str]:
 
 
 def run_template(output_path, class_details):
+    if class_details["class_name"] == "String":
+        return
     for template_info in template_files:
         resource_file = Path(
             os.path.join(

--- a/cimgen/languages/modernpython/templates/cimpy_class_template.mustache
+++ b/cimgen/languages/modernpython/templates/cimpy_class_template.mustache
@@ -33,6 +33,7 @@ class {{class_name}}({{sub_class_of}}):
             ],
             "is_used": {{#is_used}}True{{/is_used}}{{^is_used}}False{{/is_used}},
             "is_class_attribute": {{#is_class_attribute}}True{{/is_class_attribute}}{{^is_class_attribute}}False{{/is_class_attribute}},
+            "is_datatype_attribute": {{#is_datatype_attribute}}True{{/is_datatype_attribute}}{{^is_datatype_attribute}}False{{/is_datatype_attribute}},
             "is_enum_attribute": {{#is_enum_attribute}}True{{/is_enum_attribute}}{{^is_enum_attribute}}False{{/is_enum_attribute}},
             "is_list_attribute": {{#is_list_attribute}}True{{/is_list_attribute}}{{^is_list_attribute}}False{{/is_list_attribute}},
             "is_primitive_attribute": {{#is_primitive_attribute}}True{{/is_primitive_attribute}}{{^is_primitive_attribute}}False{{/is_primitive_attribute}},

--- a/cimgen/languages/modernpython/templates/cimpy_class_template.mustache
+++ b/cimgen/languages/modernpython/templates/cimpy_class_template.mustache
@@ -23,8 +23,8 @@ class {{class_name}}({{sub_class_of}}):
     """
 
     {{#attributes}}
-    {{label}}: {{#setType}}{{dataType}}{{/setType}} = Field(
-        {{#setDefault}}{{dataType}}{{/setDefault}},
+    {{label}}: {{#setType}}{{.}}{{/setType}} = Field(
+        {{#setDefault}}{{.}}{{/setDefault}},
         json_schema_extra={
             "in_profiles": [
                 {{#attr_origin}}

--- a/cimgen/languages/modernpython/utils/chevron_writer.py
+++ b/cimgen/languages/modernpython/utils/chevron_writer.py
@@ -8,7 +8,7 @@ from pycgmes.utils.constants import NAMESPACES
 from pycgmes.utils.profile import BaseProfile, Profile
 
 
-class Writer:
+class ChevronWriter:
     """Class for writing CIM RDF/XML files."""
 
     def __init__(self, objects: dict[str, Base]):
@@ -96,14 +96,15 @@ class Writer:
         about = []
         for rdfid, obj in self.objects.items():
             typ = obj.apparent_name()
-            if typ in class_profile_map and Writer.is_class_matching_profile(obj, profile):
+            if typ in class_profile_map and ChevronWriter.is_class_matching_profile(obj, profile):
                 class_profile = class_profile_map[typ]
                 main_entry_of_object = class_profile == profile
 
                 attributes = []
-                for attr, attr_infos in Writer.get_attribute_infos(obj).items():
+                for attr, attr_infos in ChevronWriter.get_attribute_infos(obj).items():
                     value = attr_infos["value"]
-                    if value and attr != "mRID" and Writer.get_attribute_profile(obj, attr, class_profile) == profile:
+                    attribute_profile = ChevronWriter.get_attribute_profile(obj, attr, class_profile)
+                    if value and attr != "mRID" and attribute_profile == profile:
                         if isinstance(value, (list, tuple)):
                             attributes.extend(attr_infos | {"value": v} for v in value)
                         else:
@@ -150,7 +151,7 @@ class Writer:
         :param obj_list:  List of CIM objects.
         :return:          Mapping of CIM type to profile.
         """
-        return {obj.apparent_name(): Writer.get_class_profile(obj) for obj in obj_list}
+        return {obj.apparent_name(): ChevronWriter.get_class_profile(obj) for obj in obj_list}
 
     @staticmethod
     def get_attribute_profile(obj: Base, attr: str, class_profile: BaseProfile) -> BaseProfile | None:

--- a/cimgen/languages/modernpython/utils/export_template.mustache
+++ b/cimgen/languages/modernpython/utils/export_template.mustache
@@ -13,6 +13,9 @@
     {{#is_class_attribute}}
     <cim:{{attr_name}} rdf:resource="#{{value}}" />
     {{/is_class_attribute}}
+    {{#is_datatype_attribute}}
+    <cim:{{attr_name}}>{{value}}</cim:{{attr_name}}>
+    {{/is_datatype_attribute}}
     {{#is_enum_attribute}}
     <cim:{{attr_name}} rdf:resource="{{namespace}}{{value}}" />
     {{/is_enum_attribute}}
@@ -31,6 +34,9 @@
     {{#is_class_attribute}}
     <cim:{{attr_name}} rdf:resource="#{{value}}" />
     {{/is_class_attribute}}
+    {{#is_datatype_attribute}}
+    <cim:{{attr_name}}>{{value}}</cim:{{attr_name}}>
+    {{/is_datatype_attribute}}
     {{#is_enum_attribute}}
     <cim:{{attr_name}} rdf:resource="{{namespace}}{{value}}" />
     {{/is_enum_attribute}}

--- a/cimgen/languages/modernpython/utils/writer.py
+++ b/cimgen/languages/modernpython/utils/writer.py
@@ -190,6 +190,7 @@ class Writer:
                             "namespace": extra.get("namespace", obj.namespace),
                             "value": getattr(obj, attr),
                             "is_class_attribute": extra.get("is_class_attribute"),
+                            "is_datatype_attribute": extra.get("is_datatype_attribute"),
                             "is_enum_attribute": extra.get("is_enum_attribute"),
                             "is_list_attribute": extra.get("is_list_attribute"),
                             "is_primitive_attribute": extra.get("is_primitive_attribute"),

--- a/cimgen/languages/python/lang_pack.py
+++ b/cimgen/languages/python/lang_pack.py
@@ -74,6 +74,8 @@ def _set_default(text, render):
 
 
 def run_template(output_path, class_details):
+    if class_details["class_name"] == "String":
+        return
     for template_info in template_files:
         class_file = os.path.join(output_path, class_details["class_name"] + template_info["ext"])
         _write_templated_file(class_file, class_details, template_info["filename"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
     "xmltodict >= 0.13.0, < 1",
     "chevron >= 0.14.0, < 1",
     "pydantic < 2",
-    "beautifulsoup4 >= 4.12.2, < 5"
+    "beautifulsoup4 >= 4.12.2, < 5",
+    "setuptools"
 ]
 
 requires-python = ">=3.11"


### PR DESCRIPTION
- Common:
  - Fix some attribute types
  - Fix handling of Decimal as float class
  - Add class property "is_a_primitive_class" and attribute property "is_primitive_float_attribute"
  - Improve _get_attribute_type in cimgen.py
  - Improve setting of long profile names
  - Refactor _merge_profiles and _merge_classes in cimgen.py
  - Add "is_a_datatype_class" and "is_datatype_attribute" (stereotype == "CIMDatatype"), use these instead of "is_a_float_class" and "is_primitive_float_attribute"
- modernpython:
  - Fix type and default of some attributes (for enums and attribute types Date, DateTime, MonthDay, Status, StreetAddress, StreetDetail, TownDetail)
  - Rename writer.py to chevron_writer.py (to prevent conflicts with the new writer in https://github.com/zaphiro-technologies/cimgen/tree/xml-generation-and-parsing)

