### PR TITLE
Fix and improve type annotations

### DIFF
--- a/cimgen/build.py
+++ b/cimgen/build.py
@@ -1,15 +1,16 @@
 import argparse
 import importlib
 import os
+from types import ModuleType
 
 from cimgen import cimgen
 
 
-def build():
+def build() -> None:
     parser = argparse.ArgumentParser(description="Generate some CIM classes.")
     parser.add_argument("--outdir", type=str, help="The output directory", required=True)
     parser.add_argument("--schemadir", type=str, help="The schema directory", required=True)
-    parser.add_argument("--langdir", type=str, help="The langpack directory", required=True)
+    parser.add_argument("--langdir", type=str, help="The language pack directory", required=True)
     parser.add_argument(
         "--cgmes_version",
         type=str,
@@ -19,9 +20,9 @@ def build():
     )
     args = parser.parse_args()
 
-    langPack = importlib.import_module(f"cimgen.languages.{args.langdir}.lang_pack")
+    lang_pack: ModuleType = importlib.import_module(f"cimgen.languages.{args.langdir}.lang_pack")
     schema_path = os.path.join(os.getcwd(), args.schemadir)
-    cimgen.cim_generate(schema_path, args.outdir, args.cgmes_version, langPack)
+    cimgen.cim_generate(schema_path, args.outdir, args.cgmes_version, lang_pack)
 
 
 if __name__ == "__main__":

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -390,10 +390,10 @@ def _parse_rdf(input_dic, version):  # NOSONAR
     return {short_profile_name: classes_map}
 
 
-# This function extracts all information needed for the creation of the python class files like the comments or the
-# class name. After the extraction the function write_files is called to write the files with the template engine
+# This function extracts all information needed for the creation of the class files like the comments or the
+# class name. After the extraction the function _write_files is called to write the files with the template engine
 # chevron
-def _write_python_files(elem_dict, lang_pack, output_path, version):
+def _write_all_files(elem_dict, lang_pack, output_path, version):
 
     # Setup called only once: make output directory, create base class, create profile class, etc.
     lang_pack.setup(output_path, _get_profile_details(package_listed_by_short_name), cim_namespace)
@@ -566,13 +566,13 @@ def addSubClassesOfSubClasses(class_dict):
 def cim_generate(directory, output_path, version, lang_pack):
     """Generates cgmes python classes from cgmes ontology
 
-    This function uses package xmltodict to parse the RDF files. The parse_rdf function sorts the classes to
+    This function uses package xmltodict to parse the RDF files. The _parse_rdf function sorts the classes to
     the corresponding packages. Since multiple files can be read, e.g. Equipment Core and Equipment Short Circuit, the
-    classes of these profiles are merged into one profile with the merge_profiles function. After that the merge_classes
+    classes of these profiles are merged into one profile with _merge_profiles. After that the _merge_classes
     function merges classes defined in multiple profiles into one class and tracks the origin of the class and their
     attributes. This information is stored in the class variable possibleProfileList and used for serialization.
-    For more information see the cimexport function in the cimpy package. Finally the
-    write_python_files function extracts all information needed for the creation of the python files and creates them
+    For more information see the cimexport function in the cimpy package. Finally the _write_all_files function
+    extracts all information needed for the creation of the language specific files and creates them
     with the template engine chevron. The attribute version of this function defines the name of the folder where the
     created classes are stored. This folder should not exist and is created in the class generation procedure.
 
@@ -617,8 +617,8 @@ def cim_generate(directory, output_path, version, lang_pack):
     # recursively add the subclasses of subclasses
     addSubClassesOfSubClasses(class_dict_with_origins)
 
-    # get information for writing python files and write python files
-    _write_python_files(class_dict_with_origins, lang_pack, output_path, version)
+    # get information for writing language specific files and write these files
+    _write_all_files(class_dict_with_origins, lang_pack, output_path, version)
 
     lang_pack.resolve_headers(output_path, version)
 

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -13,57 +13,57 @@ logger = logging.getLogger(__name__)
 
 
 class RDFSEntry:
-    def __init__(self, jsonObject: dict):
-        self.jsonDefinition = jsonObject
+    def __init__(self, json_object: dict):
+        self.json_definition = json_object
         return
 
     def as_json(self) -> dict[str, str]:
-        jsonObject = {}
+        json_object = {}
         if self.about():
-            jsonObject["about"] = self.about()
+            json_object["about"] = self.about()
         if self.comment():
-            jsonObject["comment"] = self.comment()
+            json_object["comment"] = self.comment()
         if self.datatype():
-            jsonObject["datatype"] = self.datatype()
+            json_object["datatype"] = self.datatype()
         if self.domain():
-            jsonObject["domain"] = self.domain()
+            json_object["domain"] = self.domain()
         if self.is_fixed():
-            jsonObject["is_fixed"] = self.is_fixed()
+            json_object["is_fixed"] = self.is_fixed()
         if self.label():
-            jsonObject["label"] = self.label()
+            json_object["label"] = self.label()
         if self.multiplicity():
-            jsonObject["multiplicity"] = self.multiplicity()
+            json_object["multiplicity"] = self.multiplicity()
         if self.range():
-            jsonObject["range"] = self.range()
+            json_object["range"] = self.range()
         if self.stereotype():
-            jsonObject["stereotype"] = self.stereotype()
+            json_object["stereotype"] = self.stereotype()
         if self.type():
-            jsonObject["type"] = self.type()
+            json_object["type"] = self.type()
         if self.subclass_of():
-            jsonObject["subclass_of"] = self.subclass_of()
+            json_object["subclass_of"] = self.subclass_of()
         if self.inverse_role():
-            jsonObject["inverse_role"] = self.inverse_role()
-        jsonObject["is_used"] = _get_bool_string(self.is_used())
-        return jsonObject
+            json_object["inverse_role"] = self.inverse_role()
+        json_object["is_used"] = _get_bool_string(self.is_used())
+        return json_object
 
     def about(self) -> str:
-        if "$rdf:about" in self.jsonDefinition:
-            return _get_rid_of_hash(RDFSEntry._get_about_or_resource(self.jsonDefinition["$rdf:about"]))
+        if "$rdf:about" in self.json_definition:
+            return _get_rid_of_hash(RDFSEntry._get_about_or_resource(self.json_definition["$rdf:about"]))
         else:
             return ""
 
     # Capitalized True/False is valid in python but not in json.
     # Do not use this function in combination with json.load()
     def is_used(self) -> bool:
-        if "cims:AssociationUsed" in self.jsonDefinition:
-            return "yes" == RDFSEntry._extract_string(self.jsonDefinition["cims:AssociationUsed"]).lower()
+        if "cims:AssociationUsed" in self.json_definition:
+            return "yes" == RDFSEntry._extract_string(self.json_definition["cims:AssociationUsed"]).lower()
         else:
             return True
 
     def comment(self) -> str:
-        if "rdfs:comment" in self.jsonDefinition:
+        if "rdfs:comment" in self.json_definition:
             return (
-                RDFSEntry._extract_text(self.jsonDefinition["rdfs:comment"])
+                RDFSEntry._extract_text(self.json_definition["rdfs:comment"])
                 .replace("–", "-")
                 .replace("“", '"')
                 .replace("”", '"')
@@ -76,74 +76,74 @@ class RDFSEntry:
             return ""
 
     def datatype(self) -> str:
-        if "cims:dataType" in self.jsonDefinition:
-            return RDFSEntry._extract_string(self.jsonDefinition["cims:dataType"])
+        if "cims:dataType" in self.json_definition:
+            return RDFSEntry._extract_string(self.json_definition["cims:dataType"])
         else:
             return ""
 
     def domain(self) -> str:
-        if "rdfs:domain" in self.jsonDefinition:
-            return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["rdfs:domain"]))
+        if "rdfs:domain" in self.json_definition:
+            return _get_rid_of_hash(RDFSEntry._extract_string(self.json_definition["rdfs:domain"]))
         else:
             return ""
 
     def is_fixed(self) -> str:
-        if "cims:isFixed" in self.jsonDefinition:
-            return RDFSEntry._extract_text(self.jsonDefinition["cims:isFixed"])
+        if "cims:isFixed" in self.json_definition:
+            return RDFSEntry._extract_text(self.json_definition["cims:isFixed"])
         else:
             return ""
 
     def keyword(self) -> str:
-        if "dcat:keyword" in self.jsonDefinition:
-            return self.jsonDefinition["dcat:keyword"]
+        if "dcat:keyword" in self.json_definition:
+            return self.json_definition["dcat:keyword"]
         else:
             return ""
 
     def inverse_role(self) -> str:
-        if "cims:inverseRoleName" in self.jsonDefinition:
-            return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["cims:inverseRoleName"]))
+        if "cims:inverseRoleName" in self.json_definition:
+            return _get_rid_of_hash(RDFSEntry._extract_string(self.json_definition["cims:inverseRoleName"]))
         else:
             return ""
 
     def label(self) -> str:
-        if "rdfs:label" in self.jsonDefinition:
-            return RDFSEntry._extract_text(self.jsonDefinition["rdfs:label"])
+        if "rdfs:label" in self.json_definition:
+            return RDFSEntry._extract_text(self.json_definition["rdfs:label"])
         else:
             return ""
 
     def multiplicity(self) -> str:
-        if "cims:multiplicity" in self.jsonDefinition:
-            return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["cims:multiplicity"]))
+        if "cims:multiplicity" in self.json_definition:
+            return _get_rid_of_hash(RDFSEntry._extract_string(self.json_definition["cims:multiplicity"]))
         else:
             return ""
 
     def range(self) -> str:
-        if "rdfs:range" in self.jsonDefinition:
-            return RDFSEntry._extract_string(self.jsonDefinition["rdfs:range"])
+        if "rdfs:range" in self.json_definition:
+            return RDFSEntry._extract_string(self.json_definition["rdfs:range"])
         else:
             return ""
 
     def stereotype(self) -> str:
-        if "cims:stereotype" in self.jsonDefinition:
-            return RDFSEntry._extract_string(self.jsonDefinition["cims:stereotype"])
+        if "cims:stereotype" in self.json_definition:
+            return RDFSEntry._extract_string(self.json_definition["cims:stereotype"])
         else:
             return ""
 
     def type(self) -> str:
-        if "rdf:type" in self.jsonDefinition:
-            return RDFSEntry._extract_string(self.jsonDefinition["rdf:type"])
+        if "rdf:type" in self.json_definition:
+            return RDFSEntry._extract_string(self.json_definition["rdf:type"])
         else:
             return ""
 
     def version_iri(self) -> str:
-        if "owl:versionIRI" in self.jsonDefinition:
-            return RDFSEntry._extract_string(self.jsonDefinition["owl:versionIRI"])
+        if "owl:versionIRI" in self.json_definition:
+            return RDFSEntry._extract_string(self.json_definition["owl:versionIRI"])
         else:
             return ""
 
     def subclass_of(self) -> str:
-        if "rdfs:subClassOf" in self.jsonDefinition:
-            return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["rdfs:subClassOf"]))
+        if "rdfs:subClassOf" in self.json_definition:
+            return _get_rid_of_hash(RDFSEntry._extract_string(self.json_definition["rdfs:subClassOf"]))
         else:
             return ""
 
@@ -457,7 +457,7 @@ def _write_all_files(
             attribute["attribute_class"] = attribute_class
 
         class_details["attributes"].sort(key=lambda d: d["label"])
-        _write_files(class_details, output_path, version)
+        _write_files(class_details, output_path)
 
 
 # Some names are encoded as #name or http://some-url#name
@@ -471,7 +471,7 @@ def _get_rid_of_hash(name: str) -> str:
     return name
 
 
-def _write_files(class_details: dict, output_path: str, version: str) -> None:
+def _write_files(class_details: dict, output_path: str) -> None:
     if not class_details["subclass_of"]:
         # If class has no subclass_of key it is a subclass of the Base class
         class_details["subclass_of"] = class_details["lang_pack"].get_base_class()
@@ -560,18 +560,18 @@ def _merge_classes(profiles_dict: dict[str, dict[str, CIMComponentDefinition]]) 
 
 
 def _recursively_add_subclasses(class_dict: dict[str, CIMComponentDefinition], class_name: str) -> list[str]:
-    newSubClasses: list[str] = []
-    theClass = class_dict[class_name]
-    for name in theClass.subclasses():
-        newSubClasses.append(name)
-        newNewSubClasses = _recursively_add_subclasses(class_dict, name)
-        newSubClasses = newSubClasses + newNewSubClasses
-    return newSubClasses
+    new_subclasses: list[str] = []
+    the_class = class_dict[class_name]
+    for name in the_class.subclasses():
+        new_subclasses.append(name)
+        new_new_subclasses = _recursively_add_subclasses(class_dict, name)
+        new_subclasses = new_subclasses + new_new_subclasses
+    return new_subclasses
 
 
 def _add_subclasses_of_subclasses(class_dict: dict[str, CIMComponentDefinition]) -> None:
-    for className in class_dict:
-        class_dict[className].set_subclasses(_recursively_add_subclasses(class_dict, className))
+    for class_name in class_dict:
+        class_dict[class_name].set_subclasses(_recursively_add_subclasses(class_dict, class_name))
 
 
 def cim_generate(directory: str, output_path: str, version: str, lang_pack: ModuleType) -> None:
@@ -616,14 +616,14 @@ def cim_generate(directory: str, output_path: str, version: str, lang_pack: Modu
     class_dict_with_origins = _merge_classes(profiles_dict)
 
     # work out the subclasses for each class by noting the reverse relationship
-    for className in class_dict_with_origins:
-        superClassName = class_dict_with_origins[className].subclass_of()
-        if superClassName:
-            if superClassName in class_dict_with_origins:
-                superClass = class_dict_with_origins[superClassName]
-                superClass.add_subclass(className)
+    for class_name in class_dict_with_origins:
+        superclass_name = class_dict_with_origins[class_name].subclass_of()
+        if superclass_name:
+            if superclass_name in class_dict_with_origins:
+                superclass = class_dict_with_origins[superclass_name]
+                superclass.add_subclass(class_name)
             else:
-                logger.error("No match for superClass in dict: %s", superClassName)
+                logger.error("No match for superclass in dict: %s", superclass_name)
 
     # recursively add the subclasses of subclasses
     _add_subclasses_of_subclasses(class_dict_with_origins)

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -474,8 +474,7 @@ def _get_rid_of_hash(name: str) -> str:
 def _write_files(class_details: dict, output_path: str, version: str) -> None:
     if not class_details["subclass_of"]:
         # If class has no subclass_of key it is a subclass of the Base class
-        class_details["subclass_of"] = class_details["lang_pack"].base["base_class"]
-        class_details["class_location"] = class_details["lang_pack"].base["class_location"](version)
+        class_details["subclass_of"] = class_details["lang_pack"].get_base_class()
         class_details["super_init"] = False
     else:
         # If class is a subclass a super().__init__() is needed

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -3,6 +3,7 @@ import os
 import textwrap
 import warnings
 from time import time
+from types import ModuleType
 
 import xmltodict
 from bs4 import BeautifulSoup
@@ -12,44 +13,44 @@ logger = logging.getLogger(__name__)
 
 
 class RDFSEntry:
-    def __init__(self, jsonObject):
+    def __init__(self, jsonObject: dict):
         self.jsonDefinition = jsonObject
         return
 
-    def asJson(self):
+    def asJson(self) -> dict[str, str]:
         jsonObject = {}
-        if self.about() is not None:
+        if self.about():
             jsonObject["about"] = self.about()
-        if self.comment() is not None:
+        if self.comment():
             jsonObject["comment"] = self.comment()
-        if self.dataType() is not None:
+        if self.dataType():
             jsonObject["dataType"] = self.dataType()
-        if self.domain() is not None:
+        if self.domain():
             jsonObject["domain"] = self.domain()
-        if self.fixed() is not None:
+        if self.fixed():
             jsonObject["isFixed"] = self.fixed()
-        if self.label() is not None:
+        if self.label():
             jsonObject["label"] = self.label()
-        if self.multiplicity() is not None:
+        if self.multiplicity():
             jsonObject["multiplicity"] = self.multiplicity()
-        if self.range() is not None:
+        if self.range():
             jsonObject["range"] = self.range()
-        if self.stereotype() is not None:
+        if self.stereotype():
             jsonObject["stereotype"] = self.stereotype()
-        if self.type() is not None:
+        if self.type():
             jsonObject["type"] = self.type()
-        if self.subClassOf() is not None:
+        if self.subClassOf():
             jsonObject["subClassOf"] = self.subClassOf()
-        if self.inverseRole() is not None:
+        if self.inverseRole():
             jsonObject["inverseRole"] = self.inverseRole()
         jsonObject["is_used"] = _get_bool_string(self.is_used())
         return jsonObject
 
-    def about(self):
+    def about(self) -> str:
         if "$rdf:about" in self.jsonDefinition:
             return _get_rid_of_hash(RDFSEntry._get_about_or_resource(self.jsonDefinition["$rdf:about"]))
         else:
-            return None
+            return ""
 
     # Capitalized True/False is valid in python but not in json.
     # Do not use this function in combination with json.load()
@@ -59,7 +60,7 @@ class RDFSEntry:
         else:
             return True
 
-    def comment(self):
+    def comment(self) -> str:
         if "rdfs:comment" in self.jsonDefinition:
             return (
                 RDFSEntry._extract_text(self.jsonDefinition["rdfs:comment"])
@@ -72,93 +73,94 @@ class RDFSEntry:
                 .replace("\n", " ")
             )
         else:
-            return None
+            return ""
 
-    def dataType(self):
+    def dataType(self) -> str:
         if "cims:dataType" in self.jsonDefinition:
             return RDFSEntry._extract_string(self.jsonDefinition["cims:dataType"])
         else:
-            return None
+            return ""
 
-    def domain(self):
+    def domain(self) -> str:
         if "rdfs:domain" in self.jsonDefinition:
             return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["rdfs:domain"]))
         else:
-            return None
+            return ""
 
-    def fixed(self):
+    def fixed(self) -> str:
         if "cims:isFixed" in self.jsonDefinition:
             return RDFSEntry._extract_text(self.jsonDefinition["cims:isFixed"])
         else:
-            return None
+            return ""
 
-    def keyword(self):
+    def keyword(self) -> str:
         if "dcat:keyword" in self.jsonDefinition:
             return self.jsonDefinition["dcat:keyword"]
         else:
-            return None
+            return ""
 
-    def inverseRole(self):
+    def inverseRole(self) -> str:
         if "cims:inverseRoleName" in self.jsonDefinition:
             return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["cims:inverseRoleName"]))
         else:
-            return None
+            return ""
 
-    def label(self):
+    def label(self) -> str:
         if "rdfs:label" in self.jsonDefinition:
             return RDFSEntry._extract_text(self.jsonDefinition["rdfs:label"])
         else:
-            return None
+            return ""
 
-    def multiplicity(self):
+    def multiplicity(self) -> str:
         if "cims:multiplicity" in self.jsonDefinition:
             return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["cims:multiplicity"]))
         else:
-            return None
+            return ""
 
-    def range(self):
+    def range(self) -> str:
         if "rdfs:range" in self.jsonDefinition:
             return RDFSEntry._extract_string(self.jsonDefinition["rdfs:range"])
         else:
-            return None
+            return ""
 
-    def stereotype(self):
+    def stereotype(self) -> str:
         if "cims:stereotype" in self.jsonDefinition:
             return RDFSEntry._extract_string(self.jsonDefinition["cims:stereotype"])
         else:
-            return None
+            return ""
 
-    def type(self):
+    def type(self) -> str:
         if "rdf:type" in self.jsonDefinition:
             return RDFSEntry._extract_string(self.jsonDefinition["rdf:type"])
         else:
-            return None
+            return ""
 
-    def version_iri(self):
+    def version_iri(self) -> str:
         if "owl:versionIRI" in self.jsonDefinition:
             return RDFSEntry._extract_string(self.jsonDefinition["owl:versionIRI"])
         else:
-            return None
+            return ""
 
-    def subClassOf(self):
+    def subClassOf(self) -> str:
         if "rdfs:subClassOf" in self.jsonDefinition:
             return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["rdfs:subClassOf"]))
         else:
-            return None
+            return ""
 
     # Extracts the text out of the dictionary after xmltodict, text is labeled by key '_'
-    def _extract_text(object_dic):
+    @staticmethod
+    def _extract_text(object_dic) -> str:
         if isinstance(object_dic, list):
             return object_dic[0]["_"]
         elif "_" in object_dic.keys():
             return object_dic["_"]
         elif "$rdfs:Literal" in object_dic.keys():
             return object_dic["$rdfs:Literal"]
-        else:
-            return ""
+        return ""
 
     # Extract String out of list or dictionary
-    def _extract_string(object_dic):
+    @staticmethod
+    def _extract_string(object_dic) -> str:
         if isinstance(object_dic, list):
             if len(object_dic) > 0:
                 if isinstance(object_dic[0], str):
@@ -169,65 +171,68 @@ class RDFSEntry:
     # The definitions are often contained within a string with a name
     # such as "$rdf:about" or "$rdf:resource", this extracts the
     # useful bit
-    def _get_about_or_resource(object_dic):
+    @staticmethod
+    def _get_about_or_resource(object_dic) -> str:
         if "$rdf:resource" in object_dic:
             return object_dic["$rdf:resource"]
         elif "$rdf:about" in object_dic:
             return object_dic["$rdf:about"]
         elif "$rdfs:Literal" in object_dic:
             return object_dic["$rdfs:Literal"]
-        return object_dic
+        elif type(object_dic) is str:
+            return object_dic
+        return ""
 
 
 class CIMComponentDefinition:
-    def __init__(self, rdfsEntry):
-        self.about = rdfsEntry.about()
-        self.attribute_list = []
-        self.comment = rdfsEntry.comment()
-        self.enum_instance_list = []
-        self.origin_list = []
-        self.super = rdfsEntry.subClassOf()
-        self.subclasses = []
-        self.stereotype = rdfsEntry.stereotype()
+    def __init__(self, rdfsEntry: RDFSEntry):
+        self.about: str = rdfsEntry.about()
+        self.attribute_list: list[dict] = []
+        self.comment: str = rdfsEntry.comment()
+        self.enum_instance_list: list[dict] = []
+        self.origin_list: list[dict] = []
+        self.super: str = rdfsEntry.subClassOf()
+        self.subclasses: list[str] = []
+        self.stereotype: str = rdfsEntry.stereotype()
 
-    def attributes(self):
+    def attributes(self) -> list[dict]:
         return self.attribute_list
 
-    def add_attribute(self, attribute):
+    def add_attribute(self, attribute: dict) -> None:
         self.attribute_list.append(attribute)
 
-    def is_an_enum_class(self):
+    def is_an_enum_class(self) -> bool:
         return len(self.enum_instance_list) > 0
 
-    def enum_instances(self):
+    def enum_instances(self) -> list[dict]:
         return self.enum_instance_list
 
-    def add_enum_instance(self, instance):
+    def add_enum_instance(self, instance: dict) -> None:
         instance["index"] = len(self.enum_instance_list)
         self.enum_instance_list.append(instance)
 
-    def origins(self):
+    def origins(self) -> list[dict]:
         return self.origin_list
 
-    def addOrigin(self, origin):
+    def addOrigin(self, origin: dict) -> None:
         self.origin_list.append(origin)
 
-    def superClass(self):
+    def superClass(self) -> str:
         return self.super
 
-    def addSubClass(self, name):
+    def addSubClass(self, name: str) -> None:
         self.subclasses.append(name)
 
-    def subClasses(self):
+    def subClasses(self) -> list[str]:
         return self.subclasses
 
-    def setSubClasses(self, classes):
+    def setSubClasses(self, classes: list[str]) -> None:
         self.subclasses = classes
 
-    def is_a_primitive_class(self):
+    def is_a_primitive_class(self) -> bool:
         return self.stereotype == "Primitive"
 
-    def is_a_datatype_class(self):
+    def is_a_datatype_class(self) -> bool:
         return self.stereotype == "CIMDatatype"
 
 
@@ -252,17 +257,17 @@ def wrap_and_clean(txt: str, width: int = 120, initial_indent="", subsequent_ind
     )
 
 
-long_profile_names = {}
-package_listed_by_short_name = {}
-cim_namespace = ""
+long_profile_names: dict[str, str] = {}
+package_listed_by_short_name: dict[str, list[str]] = {}
+cim_namespace: str = ""
 
 
-def _rdfs_entry_types(rdfs_entry: RDFSEntry, version) -> list:
+def _rdfs_entry_types(rdfs_entry: RDFSEntry, version: str) -> list[str]:
     """
     Determine the types of RDFS entry. In some case an RDFS entry can be of more than 1 type.
     """
-    entry_types = []
-    if rdfs_entry.type() is not None:
+    entry_types: list[str] = []
+    if rdfs_entry.type():
         if rdfs_entry.type() == "http://www.w3.org/2000/01/rdf-schema#Class":  # NOSONAR
             entry_types.append("class")
         if rdfs_entry.type() == "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property":  # NOSONAR
@@ -280,9 +285,9 @@ def _rdfs_entry_types(rdfs_entry: RDFSEntry, version) -> list:
     return entry_types
 
 
-def _entry_types_version_2(rdfs_entry: RDFSEntry) -> list:
-    entry_types = []
-    if rdfs_entry.stereotype() is not None:
+def _entry_types_version_2(rdfs_entry: RDFSEntry) -> list[str]:
+    entry_types: list[str] = []
+    if rdfs_entry.stereotype():
         if rdfs_entry.stereotype() == "Entsoe" and rdfs_entry.about()[-7:] == "Version":
             entry_types.append("profile_name_v2_4")
         if (
@@ -295,19 +300,19 @@ def _entry_types_version_2(rdfs_entry: RDFSEntry) -> list:
     return entry_types
 
 
-def _entry_types_version_3(rdfs_entry: RDFSEntry) -> list:
-    entry_types = []
+def _entry_types_version_3(rdfs_entry: RDFSEntry) -> list[str]:
+    entry_types: list[str] = []
     if rdfs_entry.type() == "http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#ClassCategory":  # NOSONAR
         entry_types.append("profile_name_v3")
     if rdfs_entry.about() == "Ontology":
         entry_types.append("profile_iri_v3")
-    if rdfs_entry.keyword() is not None:
+    if rdfs_entry.keyword():
         entry_types.append("short_profile_name_v3")
 
     return entry_types
 
 
-def _add_class(classes_map, rdfs_entry):
+def _add_class(classes_map: dict[str, CIMComponentDefinition], rdfs_entry: RDFSEntry) -> None:
     """
     Add class component to classes map
     """
@@ -327,20 +332,20 @@ def _add_profile_to_packages(profile_name: str, short_profile_name: str, profile
     long_profile_names[short_profile_name] = profile_name.removesuffix("Version").removesuffix("Profile")
 
 
-def _parse_rdf(input_dic, version):  # NOSONAR
-    classes_map = {}
-    profile_name = ""
-    short_profile_name = ""
-    profile_uri_list = []
-    attributes = []
-    enum_instances = []
+def _parse_rdf(input_dic: dict, version: str) -> dict[str, dict[str, CIMComponentDefinition]]:  # NOSONAR
+    classes_map: dict[str, CIMComponentDefinition] = {}
+    profile_name: str = ""
+    short_profile_name: str = ""
+    profile_uri_list: list[str] = []
+    attributes: list[dict] = []
+    enum_instances: list[dict] = []
 
     global cim_namespace
     if not cim_namespace:
         cim_namespace = input_dic["rdf:RDF"].get("$xmlns:cim")
 
     # Generates list with dictionaries as elements
-    descriptions = input_dic["rdf:RDF"]["rdf:Description"]
+    descriptions: list[dict] = input_dic["rdf:RDF"]["rdf:Description"]
 
     # Iterate over list elements
     for list_elem in descriptions:
@@ -393,7 +398,9 @@ def _parse_rdf(input_dic, version):  # NOSONAR
 # This function extracts all information needed for the creation of the class files like the comments or the
 # class name. After the extraction the function _write_files is called to write the files with the template engine
 # chevron
-def _write_all_files(elem_dict, lang_pack, output_path, version):
+def _write_all_files(
+    elem_dict: dict[str, CIMComponentDefinition], lang_pack: ModuleType, output_path: str, version: str
+) -> None:
 
     # Setup called only once: make output directory, create base class, create profile class, etc.
     lang_pack.setup(output_path, _get_profile_details(package_listed_by_short_name), cim_namespace)
@@ -452,7 +459,7 @@ def _write_all_files(elem_dict, lang_pack, output_path, version):
 
 # Some names are encoded as #name or http://some-url#name
 # This function returns the name
-def _get_rid_of_hash(name):
+def _get_rid_of_hash(name: str) -> str:
     tokens = name.split("#")
     if len(tokens) == 1:
         return tokens[0]
@@ -461,8 +468,8 @@ def _get_rid_of_hash(name):
     return name
 
 
-def _write_files(class_details, output_path, version):
-    if class_details["sub_class_of"] is None:
+def _write_files(class_details: dict, output_path: str, version: str) -> None:
+    if not class_details["sub_class_of"]:
         # If class has no subClassOf key it is a subclass of the Base class
         class_details["sub_class_of"] = class_details["langPack"].base["base_class"]
         class_details["class_location"] = class_details["langPack"].base["class_location"](version)
@@ -486,8 +493,10 @@ def _write_files(class_details, output_path, version):
 # If multiple CGMES schema files for one profile are read, e.g. Equipment Core and Equipment Core Short Circuit
 # this function merges these into one profile, e.g. Equipment, after this function only one dictionary entry for each
 # profile exists. The profiles_array contains one entry for each CGMES schema file which was read.
-def _merge_profiles(profiles_array):
-    profiles_dict = {}
+def _merge_profiles(
+    profiles_array: list[dict[str, dict[str, CIMComponentDefinition]]]
+) -> dict[str, dict[str, CIMComponentDefinition]]:
+    profiles_dict: dict[str, dict[str, CIMComponentDefinition]] = {}
     # Iterate through array elements
     for elem_dict in profiles_array:
         # Iterate over profile names
@@ -512,8 +521,8 @@ def _merge_profiles(profiles_array):
 # This function merges the classes defined in all profiles into one class with all attributes defined in any profile.
 # The origin of the class definitions and the origin of the attributes of a class are tracked and used to generate
 # the possibleProfileList used for the serialization.
-def _merge_classes(profiles_dict):
-    class_dict = {}
+def _merge_classes(profiles_dict: dict[str, dict[str, CIMComponentDefinition]]) -> dict[str, CIMComponentDefinition]:
+    class_dict: dict[str, CIMComponentDefinition] = {}
     # Iterate over profiles
     for profile_key, new_class_dict in profiles_dict.items():
         origin = {"origin": profile_key}
@@ -548,8 +557,8 @@ def _merge_classes(profiles_dict):
     return class_dict
 
 
-def recursivelyAddSubClasses(class_dict, class_name):
-    newSubClasses = []
+def recursivelyAddSubClasses(class_dict: dict[str, CIMComponentDefinition], class_name: str) -> list[str]:
+    newSubClasses: list[str] = []
     theClass = class_dict[class_name]
     for name in theClass.subClasses():
         newSubClasses.append(name)
@@ -558,13 +567,13 @@ def recursivelyAddSubClasses(class_dict, class_name):
     return newSubClasses
 
 
-def addSubClassesOfSubClasses(class_dict):
+def addSubClassesOfSubClasses(class_dict: dict[str, CIMComponentDefinition]) -> None:
     for className in class_dict:
         class_dict[className].setSubClasses(recursivelyAddSubClasses(class_dict, className))
 
 
-def cim_generate(directory, output_path, version, lang_pack):
-    """Generates cgmes python classes from cgmes ontology
+def cim_generate(directory: str, output_path: str, version: str, lang_pack: ModuleType) -> None:
+    """Generates cgmes classes from cgmes ontology
 
     This function uses package xmltodict to parse the RDF files. The _parse_rdf function sorts the classes to
     the corresponding packages. Since multiple files can be read, e.g. Equipment Core and Equipment Short Circuit, the
@@ -581,7 +590,7 @@ def cim_generate(directory, output_path, version, lang_pack):
     :param output_path: CGMES version, e.g. version = "cgmes_v2_4_15"
     :param lang_pack:   python module containing language specific functions
     """
-    profiles_array = []
+    profiles_array: list[dict[str, dict[str, CIMComponentDefinition]]] = []
 
     t0 = time()
 
@@ -607,7 +616,7 @@ def cim_generate(directory, output_path, version, lang_pack):
     # work out the subclasses for each class by noting the reverse relationship
     for className in class_dict_with_origins:
         superClassName = class_dict_with_origins[className].superClass()
-        if superClassName is not None:
+        if superClassName:
             if superClassName in class_dict_with_origins:
                 superClass = class_dict_with_origins[superClassName]
                 superClass.addSubClass(className)
@@ -625,9 +634,9 @@ def cim_generate(directory, output_path, version, lang_pack):
     logger.info("Elapsed Time: {}s\n\n".format(time() - t0))
 
 
-def _get_profile_details(cgmes_profile_uris):
-    profile_details = []
-    sorted_profile_keys = _get_sorted_profile_keys(cgmes_profile_uris.keys())
+def _get_profile_details(cgmes_profile_uris: dict[str, list[str]]) -> list[dict]:
+    profile_details: list[dict] = []
+    sorted_profile_keys = _get_sorted_profile_keys(list(cgmes_profile_uris.keys()))
     for index, profile in enumerate(sorted_profile_keys):
         profile_info = {
             "index": index,
@@ -639,7 +648,7 @@ def _get_profile_details(cgmes_profile_uris):
     return profile_details
 
 
-def _get_sorted_profile_keys(profile_key_list):
+def _get_sorted_profile_keys(profile_key_list: list[str]) -> list[str]:
     """Sort profiles alphabetically, but "EQ" to the first place.
 
     Profiles should be always used in the same order when they are written into the enum class Profile.
@@ -651,7 +660,7 @@ def _get_sorted_profile_keys(profile_key_list):
     return sorted(profile_key_list, key=lambda x: x == "EQ" and "0" or x)
 
 
-def _get_recommended_class_profiles(elem_dict):
+def _get_recommended_class_profiles(elem_dict: dict[str, CIMComponentDefinition]) -> dict[str, str]:
     """Get the recommended profiles for all classes.
 
     This function searches for the recommended profile of each class.
@@ -667,7 +676,7 @@ def _get_recommended_class_profiles(elem_dict):
                       and the superclass of each class (elem_dict[class_name].superClass()).
     :return:          Mapping of class to profile.
     """
-    recommended_class_profiles = {}
+    recommended_class_profiles: dict[str, str] = {}
     for class_name in elem_dict.keys():
         class_origin = elem_dict[class_name].origins()
         class_profiles = [origin["origin"] for origin in class_origin]
@@ -704,7 +713,7 @@ def _get_attribute_class(attribute: dict) -> str:
     :param attribute: Dictionary with information about an attribute of a class.
     :return:          Class name of the attribute.
     """
-    name = attribute.get("range") or attribute.get("dataType")
+    name = attribute.get("range") or attribute.get("dataType") or ""
     return _get_rid_of_hash(name)
 
 

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -17,18 +17,18 @@ class RDFSEntry:
         self.jsonDefinition = jsonObject
         return
 
-    def asJson(self) -> dict[str, str]:
+    def as_json(self) -> dict[str, str]:
         jsonObject = {}
         if self.about():
             jsonObject["about"] = self.about()
         if self.comment():
             jsonObject["comment"] = self.comment()
-        if self.dataType():
-            jsonObject["dataType"] = self.dataType()
+        if self.datatype():
+            jsonObject["datatype"] = self.datatype()
         if self.domain():
             jsonObject["domain"] = self.domain()
-        if self.fixed():
-            jsonObject["isFixed"] = self.fixed()
+        if self.is_fixed():
+            jsonObject["is_fixed"] = self.is_fixed()
         if self.label():
             jsonObject["label"] = self.label()
         if self.multiplicity():
@@ -39,10 +39,10 @@ class RDFSEntry:
             jsonObject["stereotype"] = self.stereotype()
         if self.type():
             jsonObject["type"] = self.type()
-        if self.subClassOf():
-            jsonObject["subClassOf"] = self.subClassOf()
-        if self.inverseRole():
-            jsonObject["inverseRole"] = self.inverseRole()
+        if self.subclass_of():
+            jsonObject["subclass_of"] = self.subclass_of()
+        if self.inverse_role():
+            jsonObject["inverse_role"] = self.inverse_role()
         jsonObject["is_used"] = _get_bool_string(self.is_used())
         return jsonObject
 
@@ -75,7 +75,7 @@ class RDFSEntry:
         else:
             return ""
 
-    def dataType(self) -> str:
+    def datatype(self) -> str:
         if "cims:dataType" in self.jsonDefinition:
             return RDFSEntry._extract_string(self.jsonDefinition["cims:dataType"])
         else:
@@ -87,7 +87,7 @@ class RDFSEntry:
         else:
             return ""
 
-    def fixed(self) -> str:
+    def is_fixed(self) -> str:
         if "cims:isFixed" in self.jsonDefinition:
             return RDFSEntry._extract_text(self.jsonDefinition["cims:isFixed"])
         else:
@@ -99,7 +99,7 @@ class RDFSEntry:
         else:
             return ""
 
-    def inverseRole(self) -> str:
+    def inverse_role(self) -> str:
         if "cims:inverseRoleName" in self.jsonDefinition:
             return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["cims:inverseRoleName"]))
         else:
@@ -141,7 +141,7 @@ class RDFSEntry:
         else:
             return ""
 
-    def subClassOf(self) -> str:
+    def subclass_of(self) -> str:
         if "rdfs:subClassOf" in self.jsonDefinition:
             return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["rdfs:subClassOf"]))
         else:
@@ -185,15 +185,15 @@ class RDFSEntry:
 
 
 class CIMComponentDefinition:
-    def __init__(self, rdfsEntry: RDFSEntry):
-        self.about: str = rdfsEntry.about()
+    def __init__(self, rdfs_entry: RDFSEntry):
+        self.about: str = rdfs_entry.about()
         self.attribute_list: list[dict] = []
-        self.comment: str = rdfsEntry.comment()
+        self.comment: str = rdfs_entry.comment()
         self.enum_instance_list: list[dict] = []
         self.origin_list: list[dict] = []
-        self.super: str = rdfsEntry.subClassOf()
-        self.subclasses: list[str] = []
-        self.stereotype: str = rdfsEntry.stereotype()
+        self.superclass: str = rdfs_entry.subclass_of()
+        self.subclass_list: list[str] = []
+        self.stereotype: str = rdfs_entry.stereotype()
 
     def attributes(self) -> list[dict]:
         return self.attribute_list
@@ -214,20 +214,23 @@ class CIMComponentDefinition:
     def origins(self) -> list[dict]:
         return self.origin_list
 
-    def addOrigin(self, origin: dict) -> None:
+    def add_origin(self, origin: dict) -> None:
         self.origin_list.append(origin)
 
-    def superClass(self) -> str:
-        return self.super
+    def subclass_of(self) -> str:
+        return self.superclass
 
-    def addSubClass(self, name: str) -> None:
-        self.subclasses.append(name)
+    def set_subclass_of(self, name: str) -> None:
+        self.superclass = name
 
-    def subClasses(self) -> list[str]:
-        return self.subclasses
+    def add_subclass(self, name: str) -> None:
+        self.subclass_list.append(name)
 
-    def setSubClasses(self, classes: list[str]) -> None:
-        self.subclasses = classes
+    def subclasses(self) -> list[str]:
+        return self.subclass_list
+
+    def set_subclasses(self, classes: list[str]) -> None:
+        self.subclass_list = classes
 
     def is_a_primitive_class(self) -> bool:
         return self.stereotype == "Primitive"
@@ -236,7 +239,7 @@ class CIMComponentDefinition:
         return self.stereotype == "CIMDatatype"
 
 
-def wrap_and_clean(txt: str, width: int = 120, initial_indent="", subsequent_indent="    ") -> str:
+def _wrap_and_clean(txt: str, width: int = 120, initial_indent="", subsequent_indent="    ") -> str:
     """
     Used for comments: make them fit within <width> character, including indentation.
     """
@@ -349,30 +352,30 @@ def _parse_rdf(input_dic: dict, version: str) -> dict[str, dict[str, CIMComponen
 
     # Iterate over list elements
     for list_elem in descriptions:
-        rdfsEntry = RDFSEntry(list_elem)
-        object_dic = rdfsEntry.asJson()
-        rdfs_entry_types = _rdfs_entry_types(rdfsEntry, version)
+        rdfs_entry = RDFSEntry(list_elem)
+        object_dic = rdfs_entry.as_json()
+        rdfs_entry_types = _rdfs_entry_types(rdfs_entry, version)
 
         if "class" in rdfs_entry_types:
-            _add_class(classes_map, rdfsEntry)
+            _add_class(classes_map, rdfs_entry)
         if "property" in rdfs_entry_types:
             attributes.append(object_dic)
         if "rest_non_class_category" in rdfs_entry_types:
             enum_instances.append(object_dic)
         if not profile_name:
             if "profile_name_v2_4" in rdfs_entry_types:
-                profile_name = rdfsEntry.about()
+                profile_name = rdfs_entry.about()
             if "profile_name_v3" in rdfs_entry_types:
-                profile_name = rdfsEntry.label()
+                profile_name = rdfs_entry.label()
         if not short_profile_name:
-            if "short_profile_name_v2_4" in rdfs_entry_types and rdfsEntry.fixed():
-                short_profile_name = rdfsEntry.fixed()
+            if "short_profile_name_v2_4" in rdfs_entry_types and rdfs_entry.is_fixed():
+                short_profile_name = rdfs_entry.is_fixed()
             if "short_profile_name_v3" in rdfs_entry_types:
-                short_profile_name = rdfsEntry.keyword()
-        if "profile_iri_v2_4" in rdfs_entry_types and rdfsEntry.fixed():
-            profile_uri_list.append(rdfsEntry.fixed())
+                short_profile_name = rdfs_entry.keyword()
+        if "profile_iri_v2_4" in rdfs_entry_types and rdfs_entry.is_fixed():
+            profile_uri_list.append(rdfs_entry.is_fixed())
         if "profile_iri_v3" in rdfs_entry_types:
-            profile_uri_list.append(rdfsEntry.version_iri())
+            profile_uri_list.append(rdfs_entry.version_iri())
 
     _add_profile_to_packages(profile_name, short_profile_name, profile_uri_list)
 
@@ -419,15 +422,15 @@ def _write_all_files(
             "is_a_primitive_class": elem_dict[class_name].is_a_primitive_class(),
             "is_a_datatype_class": elem_dict[class_name].is_a_datatype_class(),
             "lang_pack": lang_pack,
-            "sub_class_of": elem_dict[class_name].superClass(),
-            "sub_classes": elem_dict[class_name].subClasses(),
+            "subclass_of": elem_dict[class_name].subclass_of(),
+            "subclasses": elem_dict[class_name].subclasses(),
             "recommended_class_profile": recommended_class_profiles[class_name],
         }
 
         # extract comments
         if elem_dict[class_name].comment:
             class_details["class_comment"] = elem_dict[class_name].comment
-            class_details["wrapped_class_comment"] = wrap_and_clean(
+            class_details["wrapped_class_comment"] = _wrap_and_clean(
                 elem_dict[class_name].comment,
                 width=116,
                 initial_indent="",
@@ -438,7 +441,7 @@ def _write_all_files(
             if "comment" in attribute:
                 attribute["comment"] = attribute["comment"].replace('"', "`")
                 attribute["comment"] = attribute["comment"].replace("'", "`")
-                attribute["wrapped_comment"] = wrap_and_clean(
+                attribute["wrapped_comment"] = _wrap_and_clean(
                     attribute["comment"],
                     width=114 - len(attribute["label"]),
                     initial_indent="",
@@ -469,23 +472,23 @@ def _get_rid_of_hash(name: str) -> str:
 
 
 def _write_files(class_details: dict, output_path: str, version: str) -> None:
-    if not class_details["sub_class_of"]:
-        # If class has no subClassOf key it is a subclass of the Base class
-        class_details["sub_class_of"] = class_details["lang_pack"].base["base_class"]
+    if not class_details["subclass_of"]:
+        # If class has no subclass_of key it is a subclass of the Base class
+        class_details["subclass_of"] = class_details["lang_pack"].base["base_class"]
         class_details["class_location"] = class_details["lang_pack"].base["class_location"](version)
         class_details["super_init"] = False
     else:
         # If class is a subclass a super().__init__() is needed
         class_details["super_init"] = True
 
-    # The entry dataType for an attribute is only set for basic data types. If the entry is not set here, the attribute
-    # is a reference to another class and therefore the entry dataType is generated and set to the multiplicity
+    # The entry datatype for an attribute is only set for basic data types. If the entry is not set here, the attribute
+    # is a reference to another class and therefore the entry datatype is generated and set to the multiplicity
     for i in range(len(class_details["attributes"])):
         if (
-            "dataType" not in class_details["attributes"][i].keys()
+            "datatype" not in class_details["attributes"][i].keys()
             and "multiplicity" in class_details["attributes"][i].keys()
         ):
-            class_details["attributes"][i]["dataType"] = class_details["attributes"][i]["multiplicity"]
+            class_details["attributes"][i]["datatype"] = class_details["attributes"][i]["multiplicity"]
 
     class_details["lang_pack"].run_template(output_path, class_details)
 
@@ -531,11 +534,11 @@ def _merge_classes(profiles_dict: dict[str, dict[str, CIMComponentDefinition]]) 
             if class_key in class_dict:
                 class_infos = class_dict[class_key]
                 # some inheritance information is stored only in one of the packages. Therefore it has to be checked
-                # if the subClassOf attribute is set. See for example TopologicalNode definitions in SV and TP.
-                if not class_infos.superClass():
-                    class_infos.super = new_class_infos.superClass()
+                # if the subclass_of attribute is set. See for example TopologicalNode definitions in SV and TP.
+                if not class_infos.subclass_of():
+                    class_infos.set_subclass_of(new_class_infos.subclass_of())
                 if origin not in class_infos.origins():
-                    class_infos.addOrigin(origin)
+                    class_infos.add_origin(origin)
                 for new_attr in new_class_infos.attributes():
                     for attr in class_infos.attributes():
                         if attr["label"] == new_attr["label"]:
@@ -550,26 +553,26 @@ def _merge_classes(profiles_dict: dict[str, dict[str, CIMComponentDefinition]]) 
                         class_infos.add_attribute(new_attr)
             else:
                 # store new class and origin
-                new_class_infos.addOrigin(origin)
+                new_class_infos.add_origin(origin)
                 for attr in new_class_infos.attributes():
                     attr["attr_origin"] = [origin]
                 class_dict[class_key] = new_class_infos
     return class_dict
 
 
-def recursivelyAddSubClasses(class_dict: dict[str, CIMComponentDefinition], class_name: str) -> list[str]:
+def _recursively_add_subclasses(class_dict: dict[str, CIMComponentDefinition], class_name: str) -> list[str]:
     newSubClasses: list[str] = []
     theClass = class_dict[class_name]
-    for name in theClass.subClasses():
+    for name in theClass.subclasses():
         newSubClasses.append(name)
-        newNewSubClasses = recursivelyAddSubClasses(class_dict, name)
+        newNewSubClasses = _recursively_add_subclasses(class_dict, name)
         newSubClasses = newSubClasses + newNewSubClasses
     return newSubClasses
 
 
-def addSubClassesOfSubClasses(class_dict: dict[str, CIMComponentDefinition]) -> None:
+def _add_subclasses_of_subclasses(class_dict: dict[str, CIMComponentDefinition]) -> None:
     for className in class_dict:
-        class_dict[className].setSubClasses(recursivelyAddSubClasses(class_dict, className))
+        class_dict[className].set_subclasses(_recursively_add_subclasses(class_dict, className))
 
 
 def cim_generate(directory: str, output_path: str, version: str, lang_pack: ModuleType) -> None:
@@ -615,16 +618,16 @@ def cim_generate(directory: str, output_path: str, version: str, lang_pack: Modu
 
     # work out the subclasses for each class by noting the reverse relationship
     for className in class_dict_with_origins:
-        superClassName = class_dict_with_origins[className].superClass()
+        superClassName = class_dict_with_origins[className].subclass_of()
         if superClassName:
             if superClassName in class_dict_with_origins:
                 superClass = class_dict_with_origins[superClassName]
-                superClass.addSubClass(className)
+                superClass.add_subclass(className)
             else:
                 logger.error("No match for superClass in dict: %s", superClassName)
 
     # recursively add the subclasses of subclasses
-    addSubClassesOfSubClasses(class_dict_with_origins)
+    _add_subclasses_of_subclasses(class_dict_with_origins)
 
     # get information for writing language specific files and write these files
     _write_all_files(class_dict_with_origins, lang_pack, output_path, version)
@@ -673,7 +676,7 @@ def _get_recommended_class_profiles(elem_dict: dict[str, CIMComponentDefinition]
     :param elem_dict: Information about all classes.
                       Used are here possible class profiles (elem_dict[class_name].origins()),
                       possible attribute profiles (elem_dict[class_name].attributes()[*]["attr_origin"])
-                      and the superclass of each class (elem_dict[class_name].superClass()).
+                      and the superclass of each class (elem_dict[class_name].subclass_of()).
     :return:          Mapping of class to profile.
     """
     recommended_class_profiles: dict[str, str] = {}
@@ -695,7 +698,7 @@ def _get_recommended_class_profiles(elem_dict: dict[str, CIMComponentDefinition]
                     # Use condition attribute["is_used"]? For CGMES 2.4.13/2.4.15/3.0.0 the results wouldn't change!
                     if ambiguous_profile and profile in class_profiles:
                         profile_count_map.setdefault(profile, []).append(attribute["label"])
-            name = elem_dict[name].superClass()
+            name = elem_dict[name].subclass_of()
 
         # Set the profile with most attributes as recommended profile for this class
         if profile_count_map:
@@ -713,7 +716,7 @@ def _get_attribute_class(attribute: dict) -> str:
     :param attribute: Dictionary with information about an attribute of a class.
     :return:          Class name of the attribute.
     """
-    name = attribute.get("range") or attribute.get("dataType") or ""
+    name = attribute.get("range") or attribute.get("datatype") or ""
     return _get_rid_of_hash(name)
 
 

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -98,12 +98,6 @@ class RDFSEntry:
         else:
             return None
 
-    def title(self):
-        if "dct:title" in self.jsonDefinition:
-            return RDFSEntry._extract_text(self.jsonDefinition["dct:title"])
-        else:
-            return None
-
     def inverseRole(self):
         if "cims:inverseRoleName" in self.jsonDefinition:
             return _get_rid_of_hash(RDFSEntry._extract_string(self.jsonDefinition["cims:inverseRoleName"]))
@@ -112,15 +106,7 @@ class RDFSEntry:
 
     def label(self):
         if "rdfs:label" in self.jsonDefinition:
-            return (
-                RDFSEntry._extract_text(self.jsonDefinition["rdfs:label"])
-                .replace("–", "-")
-                .replace("“", '"')
-                .replace("”", '"')
-                .replace("’", "'")
-                .replace("°", "")
-                .replace("\n", " ")
-            )
+            return RDFSEntry._extract_text(self.jsonDefinition["rdfs:label"])
         else:
             return None
 
@@ -179,14 +165,6 @@ class RDFSEntry:
                     return object_dic[0]
                 return RDFSEntry._get_about_or_resource(object_dic[0])
         return RDFSEntry._get_about_or_resource(object_dic)
-
-    # The definitions are often contained within a string with a name
-    # such as "$rdf:about" or "$rdf:resource", this extracts the
-    # useful bit
-    def _get_literal(object_dic):
-        if "$rdfs:Literal" in object_dic:
-            return object_dic["$rdfs:Literal"]
-        return object_dic
 
     # The definitions are often contained within a string with a name
     # such as "$rdf:about" or "$rdf:resource", this extracts the

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -418,7 +418,7 @@ def _write_all_files(
             "is_an_enum_class": elem_dict[class_name].is_an_enum_class(),
             "is_a_primitive_class": elem_dict[class_name].is_a_primitive_class(),
             "is_a_datatype_class": elem_dict[class_name].is_a_datatype_class(),
-            "langPack": lang_pack,
+            "lang_pack": lang_pack,
             "sub_class_of": elem_dict[class_name].superClass(),
             "sub_classes": elem_dict[class_name].subClasses(),
             "recommended_class_profile": recommended_class_profiles[class_name],
@@ -471,8 +471,8 @@ def _get_rid_of_hash(name: str) -> str:
 def _write_files(class_details: dict, output_path: str, version: str) -> None:
     if not class_details["sub_class_of"]:
         # If class has no subClassOf key it is a subclass of the Base class
-        class_details["sub_class_of"] = class_details["langPack"].base["base_class"]
-        class_details["class_location"] = class_details["langPack"].base["class_location"](version)
+        class_details["sub_class_of"] = class_details["lang_pack"].base["base_class"]
+        class_details["class_location"] = class_details["lang_pack"].base["class_location"](version)
         class_details["super_init"] = False
     else:
         # If class is a subclass a super().__init__() is needed
@@ -487,7 +487,7 @@ def _write_files(class_details: dict, output_path: str, version: str) -> None:
         ):
             class_details["attributes"][i]["dataType"] = class_details["attributes"][i]["multiplicity"]
 
-    class_details["langPack"].run_template(output_path, class_details)
+    class_details["lang_pack"].run_template(output_path, class_details)
 
 
 # If multiple CGMES schema files for one profile are read, e.g. Equipment Core and Equipment Core Short Circuit

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -3,9 +3,10 @@ import json
 import shutil
 from pathlib import Path
 from importlib.resources import files
+from typing import Callable
 
 
-def location(version):  # NOSONAR
+def location(version: str) -> str:  # NOSONAR
     return ""
 
 
@@ -54,7 +55,7 @@ profile_template_files = [
 ]
 
 
-def get_class_location(class_name, class_map, version):  # NOSONAR
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
     return ""
 
 
@@ -70,7 +71,7 @@ partials = {
 
 
 # This is the function that runs the template.
-def run_template(output_path, class_details):
+def run_template(output_path: str, class_details: dict) -> None:
 
     if class_details["is_a_datatype_class"] or class_details["class_name"] in ("Float", "Decimal"):
         templates = float_template_files
@@ -116,7 +117,7 @@ def _create_cgmes_profile(output_path: Path, profile_details: list[dict], cim_na
 
 # This function just allows us to avoid declaring a variable called 'switch',
 # which is in the definition of the ExcBBC class.
-def label(text, render):
+def label(text: str, render: Callable[[str], str]) -> str:
     result = render(text)
     if result == "switch":
         return "_switch"
@@ -128,7 +129,7 @@ def label(text, render):
 # maps, for use in assignments.cpp and Task.cpp
 # TODO: implement this as one function, determine in template if it should be called.
 # TODO: reorganize json object so we don't have to keep doing the same processing.
-def insert_assign_fn(text, render):
+def insert_assign_fn(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     if not _attribute_is_primitive_or_datatype_or_enum(attribute_json):
@@ -148,7 +149,7 @@ def insert_assign_fn(text, render):
     )
 
 
-def insert_class_assign_fn(text, render):
+def insert_class_assign_fn(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     if _attribute_is_primitive_or_datatype_or_enum(attribute_json):
@@ -168,7 +169,7 @@ def insert_class_assign_fn(text, render):
     )
 
 
-def insert_get_fn(text, render):
+def insert_get_fn(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     if not _attribute_is_primitive_or_datatype(attribute_json):
@@ -178,7 +179,7 @@ def insert_get_fn(text, render):
     return '	get_map.emplace("cim:' + class_name + "." + label + '", &get_' + class_name + "_" + label + ");\n"
 
 
-def insert_class_get_fn(text, render):
+def insert_class_get_fn(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     if _attribute_is_primitive_or_datatype_or_enum(attribute_json):
@@ -190,7 +191,7 @@ def insert_class_get_fn(text, render):
     return '	get_map.emplace("cim:' + class_name + "." + label + '", &get_' + class_name + "_" + label + ");\n"
 
 
-def insert_enum_get_fn(text, render):
+def insert_enum_get_fn(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     if not attribute_json["is_enum_attribute"]:
@@ -200,7 +201,7 @@ def insert_enum_get_fn(text, render):
     return '	get_map.emplace("cim:' + class_name + "." + label + '", &get_' + class_name + "_" + label + ");\n"
 
 
-def create_nullptr_assigns(text, render):
+def create_nullptr_assigns(text: str, render: Callable[[str], str]) -> str:
     attributes_txt = render(text)
     if attributes_txt.strip() == "":
         return ""
@@ -219,7 +220,7 @@ def create_nullptr_assigns(text, render):
 
 # These create_ functions are used to generate the implementations for
 # the entries in the dynamic_switch maps referenced in assignments.cpp and Task.cpp
-def create_class_assign(text, render):
+def create_class_assign(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     assign = ""
@@ -325,7 +326,7 @@ bool assign_OBJECT_CLASS_LABEL(BaseClass* BaseClass_ptr1, BaseClass* BaseClass_p
     return assign
 
 
-def create_assign(text, render):
+def create_assign(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     assign = ""
@@ -377,7 +378,7 @@ bool assign_CLASS_LABEL(std::stringstream &buffer, BaseClass* BaseClass_ptr1)
     return assign
 
 
-def create_class_get(text, render):
+def create_class_get(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     if _attribute_is_primitive_or_datatype_or_enum(attribute_json):
@@ -421,7 +422,7 @@ bool get_OBJECT_CLASS_LABEL(const BaseClass* BaseClass_ptr1, std::list<const Bas
     return get
 
 
-def create_get(text, render):
+def create_get(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     get = ""
@@ -455,7 +456,7 @@ bool get_CLASS_LABEL(const BaseClass* BaseClass_ptr1, std::stringstream& buffer)
     return get
 
 
-def create_enum_get(text, render):
+def create_enum_get(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     if not attribute_json["is_enum_attribute"]:
@@ -483,13 +484,13 @@ bool get_CLASS_LABEL(const BaseClass* BaseClass_ptr1, std::stringstream& buffer)
     return get
 
 
-def attribute_decl(text, render):
+def attribute_decl(text: str, render: Callable[[str], str]) -> str:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     return _attribute_decl(attribute_json)
 
 
-def _attribute_decl(attribute):
+def _attribute_decl(attribute: dict) -> str:
     _class = attribute["attribute_class"]
     if _attribute_is_primitive_or_datatype_or_enum(attribute):
         return "CIMPP::" + _class
@@ -499,7 +500,7 @@ def _attribute_decl(attribute):
         return "CIMPP::" + _class + "*"
 
 
-def _create_attribute_includes(text, render):
+def _create_attribute_includes(text: str, render: Callable[[str], str]) -> str:
     unique = {}
     include_string = ""
     inputText = render(text)
@@ -515,7 +516,7 @@ def _create_attribute_includes(text, render):
     return include_string
 
 
-def _create_attribute_class_declarations(text, render):
+def _create_attribute_class_declarations(text: str, render: Callable[[str], str]) -> str:
     unique = {}
     include_string = ""
     inputText = render(text)
@@ -531,18 +532,17 @@ def _create_attribute_class_declarations(text, render):
     return include_string
 
 
-def _set_default(text, render):
+def _set_default(text: str, render: Callable[[str], str]) -> str:
     result = render(text)
     return set_default(result)
 
 
-def set_default(dataType):
-
+def set_default(dataType: str) -> str:
     # the field {{dataType}} either contains the multiplicity of an attribute if it is a reference or otherwise the
     # datatype of the attribute. If no datatype is set and there is also no multiplicity entry for an attribute, the
     # default value is set to None. The multiplicity is set for all attributes, but the datatype is only set for basic
     # data types. If the data type entry for an attribute is missing, the attribute contains a reference and therefore
-    # the default value is either None or [] depending on the multiplicity. See also write_python_files
+    # the default value is either None or [] depending on the multiplicity. See also _write_files in cimgen.py.
     if dataType in ["M:1", "M:0..1", "M:1..1", "M:0..n", "M:1..n", ""] or "M:" in dataType:
         return "0"
     dataType = dataType.split("#")[1]
@@ -606,7 +606,15 @@ def _is_primitive_or_enum_class(file: Path) -> bool:
     return True
 
 
-def _create_header_include_file(directory, header_include_filename, header, footer, before, after, blacklist):
+def _create_header_include_file(
+    directory: Path,
+    header_include_filename: str,
+    header: list[str],
+    footer: list[str],
+    before: str,
+    after: str,
+    blacklist: list[str],
+) -> None:
     lines = []
     for file in sorted(directory.glob("*.hpp"), key=lambda f: f.stem):
         basename = file.stem
@@ -621,7 +629,7 @@ def _create_header_include_file(directory, header_include_filename, header, foot
         f.writelines(header)
 
 
-def resolve_headers(path: str, version: str):  # NOSONAR
+def resolve_headers(path: str, version: str) -> None:  # NOSONAR
     class_list_header = [
         "#ifndef CIMCLASSLIST_H\n",
         "#define CIMCLASSLIST_H\n",

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -6,10 +6,6 @@ from importlib.resources import files
 from typing import Callable
 
 
-def location(version: str) -> str:  # NOSONAR
-    return ""
-
-
 # Setup called only once: make output directory, create base class, create profile class, etc.
 # This just makes sure we have somewhere to write the classes.
 # cgmes_profile_details contains index, names and uris for each profile.
@@ -26,8 +22,6 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
         shutil.copy(file, dest_file)
     _create_cgmes_profile(dest_dir, cgmes_profile_details, cim_namespace)
 
-
-base = {"base_class": "BaseClass", "class_location": location}
 
 # These are the files that are used to generate the header and object files.
 # There is a template set for the large number of classes that are floats. They
@@ -54,11 +48,6 @@ profile_template_files = [
     {"filename": "cpp_cgmesProfile_object_template.mustache", "ext": ".cpp"},
 ]
 
-
-def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
-    return ""
-
-
 partials = {
     "attribute_decl": "{{#lang_pack.attribute_decl}}{{.}}{{/lang_pack.attribute_decl}}",
     "label_without_keyword": "{{#lang_pack.label_without_keyword}}{{label}}{{/lang_pack.label_without_keyword}}",
@@ -80,6 +69,14 @@ partials = {
     "{{attributes}}{{/lang_pack.create_attribute_class_declarations}}",
     "set_default": "{{#lang_pack.set_default}}{{datatype}}{{/lang_pack.set_default}}",
 }
+
+
+def get_base_class() -> str:
+    return "BaseClass"
+
+
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
+    return ""
 
 
 # This is the function that runs the template.

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -78,7 +78,7 @@ partials = {
     "{{attributes}}{{/lang_pack.create_attribute_includes}}",
     "create_attribute_class_declarations": "{{#lang_pack.create_attribute_class_declarations}}"
     "{{attributes}}{{/lang_pack.create_attribute_class_declarations}}",
-    "set_default": "{{#lang_pack.set_default}}{{dataType}}{{/lang_pack.set_default}}",
+    "set_default": "{{#lang_pack.set_default}}{{datatype}}{{/lang_pack.set_default}}",
 }
 
 
@@ -243,8 +243,8 @@ def create_class_assign(text: str, render: Callable[[str], str]) -> str:
     if _attribute_is_primitive_or_datatype_or_enum(attribute_json):
         return ""
     if attribute_json["is_list_attribute"]:
-        if "inverseRole" in attribute_json:
-            inverse = attribute_json["inverseRole"].split(".")
+        if "inverse_role" in attribute_json:
+            inverse = attribute_json["inverse_role"].split(".")
             assign = (
                 """
 bool assign_INVERSEC_INVERSEL(BaseClass*, BaseClass*);
@@ -290,8 +290,8 @@ bool assign_OBJECT_CLASS_LABEL(BaseClass* BaseClass_ptr1, BaseClass* BaseClass_p
                 .replace("ATTRIBUTE_CLASS", attribute_class)
                 .replace("LABEL", attribute_json["label"])
             )
-    elif "inverseRole" in attribute_json:
-        inverse = attribute_json["inverseRole"].split(".")
+    elif "inverse_role" in attribute_json:
+        inverse = attribute_json["inverse_role"].split(".")
         assign = (
             """
 bool assign_INVERSEC_INVERSEL(BaseClass*, BaseClass*);
@@ -518,11 +518,11 @@ def _attribute_decl(attribute: dict) -> str:
 def create_attribute_includes(text: str, render: Callable[[str], str]) -> str:
     unique = {}
     include_string = ""
-    inputText = render(text)
-    jsonString = inputText.replace("'", '"')
-    jsonStringNoHtmlEsc = jsonString.replace("&quot;", '"')
-    if jsonStringNoHtmlEsc is not None and jsonStringNoHtmlEsc != "":
-        attributes = json.loads(jsonStringNoHtmlEsc)
+    input_text = render(text)
+    json_string = input_text.replace("'", '"')
+    json_string_no_html_esc = json_string.replace("&quot;", '"')
+    if json_string_no_html_esc:
+        attributes = json.loads(json_string_no_html_esc)
         for attribute in attributes:
             if _attribute_is_primitive_or_datatype_or_enum(attribute):
                 unique[attribute["attribute_class"]] = True
@@ -534,11 +534,11 @@ def create_attribute_includes(text: str, render: Callable[[str], str]) -> str:
 def create_attribute_class_declarations(text: str, render: Callable[[str], str]) -> str:
     unique = {}
     include_string = ""
-    inputText = render(text)
-    jsonString = inputText.replace("'", '"')
-    jsonStringNoHtmlEsc = jsonString.replace("&quot;", '"')
-    if jsonStringNoHtmlEsc is not None and jsonStringNoHtmlEsc != "":
-        attributes = json.loads(jsonStringNoHtmlEsc)
+    input_text = render(text)
+    json_string = input_text.replace("'", '"')
+    json_string_no_html_esc = json_string.replace("&quot;", '"')
+    if json_string_no_html_esc:
+        attributes = json.loads(json_string_no_html_esc)
         for attribute in attributes:
             if attribute["is_class_attribute"] or attribute["is_list_attribute"]:
                 unique[attribute["attribute_class"]] = True
@@ -552,22 +552,22 @@ def set_default(text: str, render: Callable[[str], str]) -> str:
     return _set_default(result)
 
 
-def _set_default(dataType: str) -> str:
-    # the field {{dataType}} either contains the multiplicity of an attribute if it is a reference or otherwise the
+def _set_default(datatype: str) -> str:
+    # the field {{datatype}} either contains the multiplicity of an attribute if it is a reference or otherwise the
     # datatype of the attribute. If no datatype is set and there is also no multiplicity entry for an attribute, the
     # default value is set to None. The multiplicity is set for all attributes, but the datatype is only set for basic
     # data types. If the data type entry for an attribute is missing, the attribute contains a reference and therefore
     # the default value is either None or [] depending on the multiplicity. See also _write_files in cimgen.py.
-    if dataType in ["M:1", "M:0..1", "M:1..1", "M:0..n", "M:1..n", ""] or "M:" in dataType:
+    if datatype in ["M:1", "M:0..1", "M:1..1", "M:0..n", "M:1..n", ""] or "M:" in datatype:
         return "0"
-    dataType = dataType.split("#")[1]
-    if dataType in ["integer", "Integer"]:
+    datatype = datatype.split("#")[1]
+    if datatype in ["integer", "Integer"]:
         return "0"
-    elif dataType in ["String", "DateTime", "Date"]:
+    elif datatype in ["String", "DateTime", "Date"]:
         return "''"
-    elif dataType == "Boolean":
+    elif datatype == "Boolean":
         return "false"
-    elif dataType == "Float":
+    elif datatype == "Float":
         return "0.0"
     else:
         return "nullptr"

--- a/cimgen/languages/cpp/templates/cpp_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_header_template.mustache
@@ -12,10 +12,12 @@ Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cim
 #include "{{sub_class_of}}.hpp"
 #include "BaseClassDefiner.hpp"
 #include "CGMESProfile.hpp"
-{{#langPack._create_attribute_includes}}{{attributes}}{{/langPack._create_attribute_includes}}
+{{> create_attribute_includes}}
+
 namespace CIMPP
 {
-{{#langPack._create_attribute_class_declarations}}{{attributes}}{{/langPack._create_attribute_class_declarations}}
+{{> create_attribute_class_declarations}}
+
 {{#class_comment}}
 	/*
 	{{{class_comment}}}
@@ -29,7 +31,7 @@ namespace CIMPP
 		~{{class_name}}() override;
 
 {{#attributes}}
-		{{> attribute}} {{> label}};  /* {{comment}} Default: {{#langPack._set_default}}{{dataType}}{{/langPack._set_default}} */
+		{{> attribute_decl}} {{> label_without_keyword}};  /* {{comment}} Default: {{> set_default}} */
 {{/attributes}}
 
 		static const char debugName[];

--- a/cimgen/languages/cpp/templates/cpp_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_header_template.mustache
@@ -9,7 +9,7 @@ Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cim
 #include <string>
 #include <unordered_map>
 
-#include "{{sub_class_of}}.hpp"
+#include "{{subclass_of}}.hpp"
 #include "BaseClassDefiner.hpp"
 #include "CGMESProfile.hpp"
 {{> create_attribute_includes}}
@@ -23,7 +23,7 @@ namespace CIMPP
 	{{{class_comment}}}
 	*/
 {{/class_comment}}
-	class {{class_name}} : public {{sub_class_of}}
+	class {{class_name}} : public {{subclass_of}}
 	{
 	public:
 		/* constructor initialising all attributes to null */

--- a/cimgen/languages/cpp/templates/cpp_object_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_object_template.mustache
@@ -14,7 +14,7 @@ Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cim
 
 using namespace CIMPP;
 
-{{class_name}}::{{class_name}}(){{#langPack.create_nullptr_assigns}} {{attributes}} {{/langPack.create_nullptr_assigns}} {};
+{{class_name}}::{{class_name}}(){{> create_nullptr_assigns}}
 {{class_name}}::~{{class_name}}() {};
 
 static const std::list<CGMESProfile> PossibleProfilesForClass =
@@ -47,23 +47,23 @@ std::map<std::string, std::list<CGMESProfile>>
 }
 
 {{#attributes}}
-{{#langPack.create_assign}}{{.}}{{/langPack.create_assign}}
+{{> create_assign}}
 {{/attributes}}
 
 {{#attributes}}
-{{#langPack.create_class_assign}}{{.}}{{/langPack.create_class_assign}}
+{{> create_class_assign}}
 {{/attributes}}
 
 {{#attributes}}
-{{#langPack.create_get}}{{.}}{{/langPack.create_get}}
+{{> create_get}}
 {{/attributes}}
 
 {{#attributes}}
-{{#langPack.create_class_get}}{{.}}{{/langPack.create_class_get}}
+{{> create_class_get}}
 {{/attributes}}
 
 {{#attributes}}
-{{#langPack.create_enum_get}}{{.}}{{/langPack.create_enum_get}}
+{{> create_enum_get}}
 {{/attributes}}
 
 const char {{class_name}}::debugName[] = "{{class_name}}";

--- a/cimgen/languages/cpp/templates/cpp_object_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_object_template.mustache
@@ -41,7 +41,7 @@ std::map<std::string, std::list<CGMESProfile>>
 {{class_name}}::getPossibleProfilesForAttributes() const
 {
 	auto map = PossibleProfilesForAttributes;
-	auto&& parent_map = {{sub_class_of}}::getPossibleProfilesForAttributes();
+	auto&& parent_map = {{subclass_of}}::getPossibleProfilesForAttributes();
 	map.insert(parent_map.begin(), parent_map.end());
 	return map;
 }
@@ -93,7 +93,7 @@ void {{class_name}}::addClassAssignFnsToMap(std::unordered_map<std::string, clas
 
 void {{class_name}}::addPrimitiveGetFnsToMap(std::map<std::string, get_function>& get_map) const
 {
-	{{sub_class_of}}::addPrimitiveGetFnsToMap(get_map);
+	{{subclass_of}}::addPrimitiveGetFnsToMap(get_map);
 {{#attributes}}
 {{> insert_get}}
 {{/attributes}}
@@ -101,7 +101,7 @@ void {{class_name}}::addPrimitiveGetFnsToMap(std::map<std::string, get_function>
 
 void {{class_name}}::addClassGetFnsToMap(std::map<std::string, class_get_function>& get_map) const
 {
-	{{sub_class_of}}::addClassGetFnsToMap(get_map);
+	{{subclass_of}}::addClassGetFnsToMap(get_map);
 {{#attributes}}
 {{> insert_class_get}}
 {{/attributes}}
@@ -109,7 +109,7 @@ void {{class_name}}::addClassGetFnsToMap(std::map<std::string, class_get_functio
 
 void {{class_name}}::addEnumGetFnsToMap(std::map<std::string, get_function>& get_map) const
 {
-	{{sub_class_of}}::addEnumGetFnsToMap(get_map);
+	{{subclass_of}}::addEnumGetFnsToMap(get_map);
 {{#attributes}}
 {{> insert_enum_get}}
 {{/attributes}}

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -43,7 +43,7 @@ def get_class_location(class_name: str, class_map: dict, version: str) -> str:  
 
 
 partials = {
-    "label": "{{#langPack.label}}{{label}}{{/langPack.label}}",
+    "label": "{{#lang_pack.label}}{{label}}{{/lang_pack.label}}",
 }
 
 

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -2,9 +2,10 @@ import shutil
 import chevron
 from pathlib import Path
 from importlib.resources import files
+from typing import Callable
 
 
-def location(version):  # NOSONAR
+def location(version: str) -> str:  # NOSONAR
     return ""
 
 
@@ -13,7 +14,7 @@ def location(version):  # NOSONAR
 # cgmes_profile_details contains index, names and uris for each profile.
 # We don't use that here because we aren't exporting into
 # separate profiles.
-def setup(output_path: str, cgmes_profile_details: list, cim_namespace: str):  # NOSONAR
+def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: str) -> None:  # NOSONAR
     source_dir = Path(__file__).parent
     dest_dir = Path(output_path)
     for file in dest_dir.glob("**/*.java"):
@@ -37,7 +38,7 @@ enum_template_files = [{"filename": "java_enum.mustache", "ext": ".java"}]
 string_template_files = [{"filename": "java_string.mustache", "ext": ".java"}]
 
 
-def get_class_location(class_name, class_map, version):  # NOSONAR
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
     return ""
 
 
@@ -47,7 +48,7 @@ partials = {
 
 
 # This is the function that runs the template.
-def run_template(output_path, class_details):
+def run_template(output_path: str, class_details: dict) -> None:
 
     if class_details["is_a_datatype_class"] or class_details["class_name"] in ("Float", "Decimal"):
         templates = float_template_files
@@ -68,7 +69,7 @@ def run_template(output_path, class_details):
         _write_templated_file(class_file, class_details, template_info["filename"])
 
 
-def _write_templated_file(class_file, class_details, template_filename):
+def _write_templated_file(class_file: Path, class_details: dict, template_filename: str) -> None:
     with class_file.open("w", encoding="utf-8") as file:
         templates = files("cimgen.languages.java.templates")
         with templates.joinpath(template_filename).open(encoding="utf-8") as f:
@@ -83,7 +84,7 @@ def _write_templated_file(class_file, class_details, template_filename):
 
 # This function just allows us to avoid declaring a variable called 'switch',
 # which is in the definition of the ExcBBC class.
-def label(text, render):
+def label(text: str, render: Callable[[str], str]) -> str:
     result = render(text)
     if result == "switch":
         return "_switch"
@@ -104,7 +105,15 @@ class_blacklist = [
 ]
 
 
-def _create_header_include_file(directory, header_include_filename, header, footer, before, after, blacklist):
+def _create_header_include_file(
+    directory: Path,
+    header_include_filename: str,
+    header: list[str],
+    footer: list[str],
+    before: str,
+    after: str,
+    blacklist: list[str],
+) -> None:
     lines = []
     for file in sorted(directory.glob("*.java"), key=lambda f: f.stem):
         basename = file.stem
@@ -120,7 +129,7 @@ def _create_header_include_file(directory, header_include_filename, header, foot
         f.writelines(header)
 
 
-def resolve_headers(path: str, version: str):  # NOSONAR
+def resolve_headers(path: str, version: str) -> None:  # NOSONAR
     class_list_header = [
         "/*\n",
         "Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen\n",

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -5,10 +5,6 @@ from importlib.resources import files
 from typing import Callable
 
 
-def location(version: str) -> str:  # NOSONAR
-    return ""
-
-
 # Setup called only once: make output directory, create base class, create profile class, etc.
 # This just makes sure we have somewhere to write the classes.
 # cgmes_profile_details contains index, names and uris for each profile.
@@ -26,8 +22,6 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
         shutil.copy(file, dest_file)
 
 
-base = {"base_class": "BaseClass", "class_location": location}
-
 # These are the files that are used to generate the java files.
 # There is a template set for the large number of classes that are floats. They
 # have unit, multiplier and value attributes in the schema, but only appear in
@@ -37,14 +31,17 @@ float_template_files = [{"filename": "java_float.mustache", "ext": ".java"}]
 enum_template_files = [{"filename": "java_enum.mustache", "ext": ".java"}]
 string_template_files = [{"filename": "java_string.mustache", "ext": ".java"}]
 
-
-def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
-    return ""
-
-
 partials = {
     "label": "{{#lang_pack.label}}{{label}}{{/lang_pack.label}}",
 }
+
+
+def get_base_class() -> str:
+    return "BaseClass"
+
+
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
+    return ""
 
 
 # This is the function that runs the template.

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -26,10 +26,10 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
 # There is a template set for the large number of classes that are floats. They
 # have unit, multiplier and value attributes in the schema, but only appear in
 # the file as a float string.
-template_files = [{"filename": "java_class.mustache", "ext": ".java"}]
-float_template_files = [{"filename": "java_float.mustache", "ext": ".java"}]
-enum_template_files = [{"filename": "java_enum.mustache", "ext": ".java"}]
-string_template_files = [{"filename": "java_string.mustache", "ext": ".java"}]
+class_template_file = {"filename": "java_class.mustache", "ext": ".java"}
+float_template_file = {"filename": "java_float.mustache", "ext": ".java"}
+enum_template_file = {"filename": "java_enum.mustache", "ext": ".java"}
+string_template_file = {"filename": "java_string.mustache", "ext": ".java"}
 
 partials = {
     "label": "{{#lang_pack.label}}{{label}}{{/lang_pack.label}}",
@@ -48,22 +48,21 @@ def get_class_location(class_name: str, class_map: dict, version: str) -> str:  
 def run_template(output_path: str, class_details: dict) -> None:
 
     if class_details["is_a_datatype_class"] or class_details["class_name"] in ("Float", "Decimal"):
-        templates = float_template_files
+        template = float_template_file
     elif class_details["is_an_enum_class"]:
-        templates = enum_template_files
+        template = enum_template_file
     elif class_details["is_a_primitive_class"]:
-        templates = string_template_files
+        template = string_template_file
     else:
-        templates = template_files
+        template = class_template_file
 
     if class_details["class_name"] in ("Integer", "Boolean"):
         # These classes are defined already
         # We have to implement operators for them
         return
 
-    for template_info in templates:
-        class_file = Path(output_path) / (class_details["class_name"] + template_info["ext"])
-        _write_templated_file(class_file, class_details, template_info["filename"])
+    class_file = Path(output_path) / (class_details["class_name"] + template["ext"])
+    _write_templated_file(class_file, class_details, template["filename"])
 
 
 def _write_templated_file(class_file: Path, class_details: dict, template_filename: str) -> None:

--- a/cimgen/languages/java/templates/java_class.mustache
+++ b/cimgen/languages/java/templates/java_class.mustache
@@ -13,7 +13,7 @@ import java.util.Set;
  * {{{class_comment}}}
  */
 {{/class_comment}}
-public class {{class_name}} extends {{sub_class_of}} {
+public class {{class_name}} extends {{subclass_of}} {
 
 	private static final Logging LOG = Logging.getLogger({{class_name}}.class);
 

--- a/cimgen/languages/javascript/lang_pack.py
+++ b/cimgen/languages/javascript/lang_pack.py
@@ -19,9 +19,9 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
 
 
 # These are the files that are used to generate the javascript files.
-template_files = [{"filename": "handlebars_template.mustache", "ext": ".js"}]
-base_template_files = [{"filename": "handlebars_baseclass_template.mustache", "ext": ".js"}]
-profile_template_files = [{"filename": "handlebars_cgmesProfile_template.mustache", "ext": ".js"}]
+template_file = {"filename": "handlebars_template.mustache", "ext": ".js"}
+base_template_file = {"filename": "handlebars_baseclass_template.mustache", "ext": ".js"}
+profile_template_file = {"filename": "handlebars_cgmesProfile_template.mustache", "ext": ".js"}
 
 partials = {}
 
@@ -118,9 +118,8 @@ def run_template(output_path: str, class_details: dict) -> None:
         sys.exit(1)
     class_details["renderAttribute"] = renderAttribute
 
-    for template_info in template_files:
-        class_file = os.path.join(output_path, class_details["class_name"] + template_info["ext"])
-        _write_templated_file(class_file, class_details, template_info["filename"])
+    class_file = os.path.join(output_path, class_details["class_name"] + template_file["ext"])
+    _write_templated_file(class_file, class_details, template_file["filename"])
 
 
 def _write_templated_file(class_file: str, class_details: dict, template_filename: str) -> None:
@@ -138,19 +137,17 @@ def _write_templated_file(class_file: str, class_details: dict, template_filenam
 
 # creates the Base class file, all classes inherit from this class
 def _create_base(output_path: str) -> None:
-    for template_info in base_template_files:
-        class_file = os.path.join(output_path, "BaseClass" + template_info["ext"])
-        _write_templated_file(class_file, {}, template_info["filename"])
+    class_file = os.path.join(output_path, "BaseClass" + base_template_file["ext"])
+    _write_templated_file(class_file, {}, base_template_file["filename"])
 
 
 def _create_cgmes_profile(output_path: str, profile_details: list[dict], cim_namespace: str) -> None:
-    for template_info in profile_template_files:
-        class_file = os.path.join(output_path, "CGMESProfile" + template_info["ext"])
-        class_details = {
-            "profiles": profile_details,
-            "cim_namespace": cim_namespace,
-        }
-        _write_templated_file(class_file, class_details, template_info["filename"])
+    class_file = os.path.join(output_path, "CGMESProfile" + profile_template_file["ext"])
+    class_details = {
+        "profiles": profile_details,
+        "cim_namespace": cim_namespace,
+    }
+    _write_templated_file(class_file, class_details, profile_template_file["filename"])
 
 
 def _get_class_type(class_details: dict) -> str:

--- a/cimgen/languages/javascript/lang_pack.py
+++ b/cimgen/languages/javascript/lang_pack.py
@@ -73,7 +73,7 @@ aggregateRenderer: dict[str, str] = {
 }
 
 
-def select_primitive_render_function(class_details: dict) -> str:
+def _select_primitive_render_function(class_details: dict) -> str:
     class_name = class_details["class_name"]
     render = ""
     if class_details["is_a_datatype_class"]:
@@ -113,7 +113,7 @@ def run_template(output_path: str, class_details: dict) -> None:
     if class_type == "enum":
         renderAttribute = aggregateRenderer["renderInstance"]
     elif class_type == "primitive":
-        renderAttribute = select_primitive_render_function(class_details)
+        renderAttribute = _select_primitive_render_function(class_details)
     else:
         renderAttribute = aggregateRenderer["renderClass"]
     if renderAttribute == "":

--- a/cimgen/languages/javascript/lang_pack.py
+++ b/cimgen/languages/javascript/lang_pack.py
@@ -4,7 +4,7 @@ import sys
 from importlib.resources import files
 
 
-def location(version):  # NOSONAR
+def location(version: str) -> str:  # NOSONAR
     return ""
 
 
@@ -12,7 +12,7 @@ def location(version):  # NOSONAR
 # This function makes sure we have somewhere to write the classes.
 # cgmes_profile_details contains index, names and uris for each profile.
 # We use that to create the header data for the profiles.
-def setup(output_path: str, cgmes_profile_details: list, cim_namespace: str):
+def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: str) -> None:
     if not os.path.exists(output_path):
         os.makedirs(output_path)
     else:
@@ -32,11 +32,11 @@ profile_template_files = [{"filename": "handlebars_cgmesProfile_template.mustach
 partials = {}
 
 
-def get_class_location(class_name, class_map, version):  # NOSONAR
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
     return ""
 
 
-aggregateRenderer = {
+aggregateRenderer: dict[str, str] = {
     "renderFloat": "static renderAsAttribute(data) {\n\
         return templates.handlebars_cim_render_float(data)\n\
     }",
@@ -73,7 +73,7 @@ aggregateRenderer = {
 }
 
 
-def select_primitive_render_function(class_details):
+def select_primitive_render_function(class_details: dict) -> str:
     class_name = class_details["class_name"]
     render = ""
     if class_details["is_a_datatype_class"]:
@@ -100,7 +100,7 @@ def select_primitive_render_function(class_details):
 
 
 # This is the function that runs the template.
-def run_template(output_path, class_details):
+def run_template(output_path: str, class_details: dict) -> None:
     if class_details["class_name"] == "String":
         return
 
@@ -126,7 +126,7 @@ def run_template(output_path, class_details):
         _write_templated_file(class_file, class_details, template_info["filename"])
 
 
-def _write_templated_file(class_file, class_details, template_filename):
+def _write_templated_file(class_file: str, class_details: dict, template_filename: str) -> None:
     with open(class_file, "w", encoding="utf-8") as file:
         templates = files("cimgen.languages.javascript.templates")
         with templates.joinpath(template_filename).open(encoding="utf-8") as f:
@@ -140,13 +140,13 @@ def _write_templated_file(class_file, class_details, template_filename):
 
 
 # creates the Base class file, all classes inherit from this class
-def _create_base(output_path):
+def _create_base(output_path: str) -> None:
     for template_info in base_template_files:
         class_file = os.path.join(output_path, "BaseClass" + template_info["ext"])
         _write_templated_file(class_file, {}, template_info["filename"])
 
 
-def _create_cgmes_profile(output_path: str, profile_details: list, cim_namespace: str):
+def _create_cgmes_profile(output_path: str, profile_details: list[dict], cim_namespace: str) -> None:
     for template_info in profile_template_files:
         class_file = os.path.join(output_path, "CGMESProfile" + template_info["ext"])
         class_details = {
@@ -156,7 +156,7 @@ def _create_cgmes_profile(output_path: str, profile_details: list, cim_namespace
         _write_templated_file(class_file, class_details, template_info["filename"])
 
 
-def _get_class_type(class_details):
+def _get_class_type(class_details: dict) -> str:
     if class_details["is_a_primitive_class"] or class_details["is_a_datatype_class"]:
         return "primitive"
     if class_details["is_an_enum_class"]:
@@ -164,5 +164,5 @@ def _get_class_type(class_details):
     return "class"
 
 
-def resolve_headers(path: str, version: str):  # NOSONAR
+def resolve_headers(path: str, version: str) -> None:  # NOSONAR
     pass

--- a/cimgen/languages/javascript/lang_pack.py
+++ b/cimgen/languages/javascript/lang_pack.py
@@ -4,10 +4,6 @@ import sys
 from importlib.resources import files
 
 
-def location(version: str) -> str:  # NOSONAR
-    return ""
-
-
 # Setup called only once: make output directory, create base class, create profile class, etc.
 # This function makes sure we have somewhere to write the classes.
 # cgmes_profile_details contains index, names and uris for each profile.
@@ -22,19 +18,12 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
     _create_cgmes_profile(output_path, cgmes_profile_details, cim_namespace)
 
 
-base = {"base_class": "BaseClass", "class_location": location}
-
 # These are the files that are used to generate the javascript files.
 template_files = [{"filename": "handlebars_template.mustache", "ext": ".js"}]
 base_template_files = [{"filename": "handlebars_baseclass_template.mustache", "ext": ".js"}]
 profile_template_files = [{"filename": "handlebars_cgmesProfile_template.mustache", "ext": ".js"}]
 
 partials = {}
-
-
-def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
-    return ""
-
 
 aggregateRenderer: dict[str, str] = {
     "renderFloat": "static renderAsAttribute(data) {\n\
@@ -97,6 +86,14 @@ def _select_primitive_render_function(class_details: dict) -> str:
         # TODO: Implementation Required!
         render = aggregateRenderer["renderString"]
     return render
+
+
+def get_base_class() -> str:
+    return "BaseClass"
+
+
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
+    return ""
 
 
 # This is the function that runs the template.

--- a/cimgen/languages/javascript/templates/handlebars_template.mustache
+++ b/cimgen/languages/javascript/templates/handlebars_template.mustache
@@ -1,5 +1,5 @@
 import templates from "../../templates/index.js"
-import {{sub_class_of}} from "./{{sub_class_of}}.js"
+import {{subclass_of}} from "./{{subclass_of}}.js"
 import common from "../../src/common.js"
 import CGMESProfile from "./CGMESProfile.js"
 
@@ -17,10 +17,10 @@ const possibleValues = [
 ]
 {{/is_an_enum_class}}
 
-class {{class_name}} extends {{sub_class_of}} {
+class {{class_name}} extends {{subclass_of}} {
 
     static attributeHTML(object, cimmenu, classType="{{class_name}}") {
-        let attributeEntries = {{sub_class_of}}.attributeHTML(object, cimmenu, classType);
+        let attributeEntries = {{subclass_of}}.attributeHTML(object, cimmenu, classType);
         {{#attributes}}
         if ('cim:{{about}}' in object) {
             attributeEntries['filledEntries']['cim:{{about}}'] =
@@ -62,7 +62,7 @@ class {{class_name}} extends {{sub_class_of}} {
         if ( attributes.indexOf(attribute) >= 0 ) {
             return true;
         }
-        else if ( {{sub_class_of}}.isMemberAttribute(attribute) ) {
+        else if ( {{subclass_of}}.isMemberAttribute(attribute) ) {
             return true;
         }
         else {
@@ -87,9 +87,9 @@ class {{class_name}} extends {{sub_class_of}} {
     {{{renderAttribute}}}
     static subClassList() {
         let subClasses = [
-        {{#sub_classes}}
+        {{#subclasses}}
         "{{.}}",
-        {{/sub_classes}}
+        {{/subclasses}}
         ];
         return subClasses;
     }

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -44,7 +44,7 @@ datatype_template_file = {"filename": "datatype_template.mustache", "ext": ".py"
 
 
 def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
-    return f".{class_map[class_name].superClass()}"
+    return f".{class_map[class_name].subclass_of()}"
 
 
 partials = {}
@@ -114,9 +114,9 @@ def _set_datatype_attributes(attributes: list[dict]) -> dict:
     for attribute in attributes:
         if "value" in attribute.get("about", "") and "attribute_class" in attribute:
             datatype_attributes["python_type"] = _get_python_type(attribute["attribute_class"])
-        if "isFixed" in attribute:
+        if "is_fixed" in attribute:
             import_set.add(attribute["attribute_class"])
-    datatype_attributes["isFixed_imports"] = sorted(import_set)
+    datatype_attributes["is_fixed_imports"] = sorted(import_set)
     return datatype_attributes
 
 
@@ -135,8 +135,8 @@ def run_template(output_path: str, class_details: dict) -> None:
         template = enum_template_file
     else:
         template = class_template_file
-        class_details["setDefault"] = _set_default
-        class_details["setType"] = _set_type
+        class_details["set_default"] = _set_default
+        class_details["set_type"] = _set_type
         class_details["imports"] = _set_imports(class_details["attributes"])
     resource_file = _create_file(output_path, class_details, template)
     _write_templated_file(resource_file, class_details, template["filename"])

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -28,12 +28,6 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
     _create_cgmes_profile(dest_dir, cgmes_profile_details)
 
 
-def location(version: str) -> str:
-    return "..utils.base"
-
-
-base = {"base_class": "Base", "class_location": location}
-
 # These are the files that are used to generate the python files.
 class_template_file = {"filename": "class_template.mustache", "ext": ".py"}
 constants_template_file = {"filename": "constants_template.mustache", "ext": ".py"}
@@ -41,11 +35,6 @@ profile_template_file = {"filename": "profile_template.mustache", "ext": ".py"}
 enum_template_file = {"filename": "enum_template.mustache", "ext": ".py"}
 primitive_template_file = {"filename": "primitive_template.mustache", "ext": ".py"}
 datatype_template_file = {"filename": "datatype_template.mustache", "ext": ".py"}
-
-
-def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
-    return f".{class_map[class_name].subclass_of()}"
-
 
 partials = {}
 
@@ -118,6 +107,17 @@ def _set_datatype_attributes(attributes: list[dict]) -> dict:
             import_set.add(attribute["attribute_class"])
     datatype_attributes["is_fixed_imports"] = sorted(import_set)
     return datatype_attributes
+
+
+def get_base_class() -> str:
+    return "Base"
+
+
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
+    # Check if the current class has a parent class
+    if class_map[class_name].subclass_of() and class_map[class_name].subclass_of() in class_map:
+        return f".{class_map[class_name].subclass_of()}"
+    return "..utils.base"
 
 
 def run_template(output_path: str, class_details: dict) -> None:

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -4,6 +4,7 @@ import re
 import shutil
 from pathlib import Path
 from importlib.resources import files
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
     _create_cgmes_profile(dest_dir, cgmes_profile_details)
 
 
-def location(version):  # NOSONAR
+def location(version: str) -> str:
     return "..utils.base"
 
 
@@ -42,7 +43,7 @@ primitive_template_file = {"filename": "primitive_template.mustache", "ext": ".p
 datatype_template_file = {"filename": "datatype_template.mustache", "ext": ".py"}
 
 
-def get_class_location(class_name, class_map, version):  # NOSONAR
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:  # NOSONAR
     return f".{class_map[class_name].superClass()}"
 
 
@@ -50,15 +51,15 @@ partials = {}
 
 
 # called by chevron, text contains the attribute infos, which are evaluated by the renderer (see class template)
-def _set_default(text, render):
+def _set_default(text: str, render: Callable[[str], str]) -> str:
     return _get_type_and_default(text, render)[1]
 
 
-def _set_type(text, render):
+def _set_type(text: str, render: Callable[[str], str]) -> str:
     return _get_type_and_default(text, render)[0]
 
 
-def _get_type_and_default(text, render) -> tuple[str, str]:
+def _get_type_and_default(text: str, render: Callable[[str], str]) -> tuple[str, str]:
     attribute_txt = render(text)
     attribute_json = eval(attribute_txt)
     if attribute_json["is_class_attribute"]:
@@ -78,7 +79,7 @@ def _get_type_and_default(text, render) -> tuple[str, str]:
         return ("str", 'default=""')
 
 
-def _get_python_type(datatype):
+def _get_python_type(datatype: str) -> str:
     if datatype.lower() == "integer":
         return "int"
     if datatype.lower() == "boolean":
@@ -98,7 +99,7 @@ def _get_python_type(datatype):
         return "float"
 
 
-def _set_imports(attributes):
+def _set_imports(attributes: list[dict]) -> list[str]:
     import_set = set()
     for attribute in attributes:
         if attribute["is_datatype_attribute"] or attribute["is_primitive_attribute"]:
@@ -106,7 +107,7 @@ def _set_imports(attributes):
     return sorted(import_set)
 
 
-def _set_datatype_attributes(attributes) -> dict:
+def _set_datatype_attributes(attributes: list[dict]) -> dict:
     datatype_attributes = {}
     datatype_attributes["python_type"] = "None"
     import_set = set()
@@ -119,7 +120,7 @@ def _set_datatype_attributes(attributes) -> dict:
     return datatype_attributes
 
 
-def run_template(output_path, class_details):
+def run_template(output_path: str, class_details: dict) -> None:
     if class_details["is_a_primitive_class"]:
         # Primitives are never used in the in memory representation but only for
         # the schema
@@ -172,7 +173,7 @@ def _create_cgmes_profile(output_path: Path, profile_details: list[dict]) -> Non
     _write_templated_file(class_file, class_details, profile_template_file["filename"])
 
 
-def resolve_headers(path: str, version: str):
+def resolve_headers(path: str, version: str) -> None:
     """Add all classes in __init__.py"""
 
     if match := re.search(r"(?P<num>\d+_\d+_\d+)", version):  # NOSONAR

--- a/cimgen/languages/modernpython/templates/class_template.mustache
+++ b/cimgen/languages/modernpython/templates/class_template.mustache
@@ -9,14 +9,14 @@ from pydantic import Field
 from pydantic.dataclasses import dataclass
 
 from ..utils.profile import BaseProfile, Profile
-from {{class_location}} import {{sub_class_of}}
+from {{class_location}} import {{subclass_of}}
 {{#imports}}
 from .{{.}} import {{.}}
 {{/imports}}
 
 
 @dataclass
-class {{class_name}}({{sub_class_of}}):
+class {{class_name}}({{subclass_of}}):
     """
     {{{wrapped_class_comment}}}
 
@@ -26,8 +26,8 @@ class {{class_name}}({{sub_class_of}}):
     """
 
     {{#attributes}}
-    {{label}}: {{#setType}}{{.}}{{/setType}} = Field(
-        {{#setDefault}}{{.}}{{/setDefault}},
+    {{label}}: {{#set_type}}{{.}}{{/set_type}} = Field(
+        {{#set_default}}{{.}}{{/set_default}},
         json_schema_extra={
             "in_profiles": [
                 {{#attr_origin}}

--- a/cimgen/languages/modernpython/templates/datatype_template.mustache
+++ b/cimgen/languages/modernpython/templates/datatype_template.mustache
@@ -4,18 +4,18 @@ Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cim
 
 from ..utils.datatypes import CIMDatatype
 from ..utils.profile import Profile
-{{#isFixed_imports}}
+{{#is_fixed_imports}}
 from .{{.}} import {{.}}
-{{/isFixed_imports}}
+{{/is_fixed_imports}}
 
 
 {{class_name}} = CIMDatatype(
     name="{{class_name}}",
     type={{python_type}},
 {{#attributes}}
-{{#isFixed}}
-    {{label}}={{attribute_class}}.{{isFixed}},
-{{/isFixed}}
+{{#is_fixed}}
+    {{label}}={{attribute_class}}.{{is_fixed}},
+{{/is_fixed}}
 {{/attributes}}
     profiles=[{{#class_origin}}
         Profile.{{origin}},{{/class_origin}}

--- a/cimgen/languages/modernpython/templates/enum_template.mustache
+++ b/cimgen/languages/modernpython/templates/enum_template.mustache
@@ -7,9 +7,9 @@ from enum import Enum
 
 class {{class_name}}(str, Enum):
     """
-    {{{class_comment}}}  # noqa: E501
+    {{{wrapped_class_comment}}}
     """
 
     {{#enum_instances}}
-    {{label}} = "{{label}}"{{#comment}}  # {{comment}}{{/comment}}  # noqa: E501
+    {{label}} = "{{label}}"{{#comment}}  # {{comment}}{{/comment}}  # noqa: E501, E741, RUF003
     {{/enum_instances}}

--- a/cimgen/languages/modernpython/utils/base.py
+++ b/cimgen/languages/modernpython/utils/base.py
@@ -6,9 +6,8 @@ from typing import Any, TypeAlias, TypedDict
 
 from pydantic.dataclasses import dataclass
 
-from .constants import NAMESPACES
-
 from .config import cgmes_resource_config
+from .constants import NAMESPACES
 from .profile import BaseProfile
 
 

--- a/cimgen/languages/modernpython/utils/datatypes.py
+++ b/cimgen/languages/modernpython/utils/datatypes.py
@@ -1,19 +1,18 @@
-from pydantic import Field
 from typing import List, Optional, Union
 
-from .constants import NAMESPACES
+from pydantic import Field
 from pydantic.dataclasses import dataclass
 
-from .config import cgmes_resource_config
-from .profile import BaseProfile
+from ..resources.Currency import Currency
 from ..resources.UnitMultiplier import UnitMultiplier
 from ..resources.UnitSymbol import UnitSymbol
-from ..resources.Currency import Currency
+from .config import cgmes_resource_config
+from .constants import NAMESPACES
+from .profile import BaseProfile
 
 
 @dataclass(config=cgmes_resource_config)
 class Primitive:
-
     name: str = Field(frozen=True)
     type: object = Field(frozen=True)
     namespace: str = Field(frozen=True, default=NAMESPACES["cim"])
@@ -22,7 +21,6 @@ class Primitive:
 
 @dataclass(config=cgmes_resource_config)
 class CIMDatatype(Primitive):
-
     multiplier: Optional[UnitMultiplier] = Field(default=None, frozen=True)
     unit: Optional[Union[UnitSymbol, Currency]] = Field(default=None, frozen=True)
     denominatorMultiplier: Optional[UnitMultiplier] = Field(default=None, frozen=True)

--- a/cimgen/languages/python/lang_pack.py
+++ b/cimgen/languages/python/lang_pack.py
@@ -24,8 +24,8 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
 
 
 # These are the files that are used to generate the python files.
-template_files = [{"filename": "cimpy_class_template.mustache", "ext": ".py"}]
-profile_template_files = [{"filename": "cimpy_cgmesProfile_template.mustache", "ext": ".py"}]
+class_template_file = {"filename": "cimpy_class_template.mustache", "ext": ".py"}
+profile_template_file = {"filename": "cimpy_cgmesProfile_template.mustache", "ext": ".py"}
 
 partials = {}
 
@@ -70,9 +70,8 @@ def get_class_location(class_name: str, class_map: dict, version: str) -> str:
 def run_template(output_path: str, class_details: dict) -> None:
     if class_details["class_name"] == "String":
         return
-    for template_info in template_files:
-        class_file = os.path.join(output_path, class_details["class_name"] + template_info["ext"])
-        _write_templated_file(class_file, class_details, template_info["filename"])
+    class_file = os.path.join(output_path, class_details["class_name"] + class_template_file["ext"])
+    _write_templated_file(class_file, class_details, class_template_file["filename"])
 
 
 def _write_templated_file(class_file: str, class_details: dict, template_filename: str) -> None:
@@ -106,13 +105,12 @@ def _create_base(path: str) -> None:
 
 
 def _create_cgmes_profile(output_path: str, profile_details: list[dict], cim_namespace: str) -> None:
-    for template_info in profile_template_files:
-        class_file = os.path.join(output_path, "CGMESProfile" + template_info["ext"])
-        class_details = {
-            "profiles": profile_details,
-            "cim_namespace": cim_namespace,
-        }
-        _write_templated_file(class_file, class_details, template_info["filename"])
+    class_file = os.path.join(output_path, "CGMESProfile" + profile_template_file["ext"])
+    class_details = {
+        "profiles": profile_details,
+        "cim_namespace": cim_namespace,
+    }
+    _write_templated_file(class_file, class_details, profile_template_file["filename"])
 
 
 class_blacklist = ["CGMESProfile"]

--- a/cimgen/languages/python/lang_pack.py
+++ b/cimgen/languages/python/lang_pack.py
@@ -36,19 +36,19 @@ profile_template_files = [{"filename": "cimpy_cgmesProfile_template.mustache", "
 
 def get_class_location(class_name: str, class_map: dict, version: str) -> str:
     # Check if the current class has a parent class
-    if class_map[class_name].superClass() and class_map[class_name].superClass() in class_map:
-        return "cimpy." + version + "." + class_map[class_name].superClass()
+    if class_map[class_name].subclass_of() and class_map[class_name].subclass_of() in class_map:
+        return "cimpy." + version + "." + class_map[class_name].subclass_of()
     return location(version)
 
 
 partials = {}
 
 
-# called by chevron, text contains the label {{dataType}}, which is evaluated by the renderer (see class template)
+# called by chevron, text contains the label {{datatype}}, which is evaluated by the renderer (see class template)
 def _set_default(text: str, render: Callable[[str], str]) -> str:
     result = render(text)
 
-    # the field {{dataType}} either contains the multiplicity of an attribute if it is a reference or otherwise the
+    # the field {{datatype}} either contains the multiplicity of an attribute if it is a reference or otherwise the
     # datatype of the attribute. If no datatype is set and there is also no multiplicity entry for an attribute, the
     # default value is set to None. The multiplicity is set for all attributes, but the datatype is only set for basic
     # data types. If the data type entry for an attribute is missing, the attribute contains a reference and therefore
@@ -80,7 +80,7 @@ def run_template(output_path: str, class_details: dict) -> None:
 
 def _write_templated_file(class_file: str, class_details: dict, template_filename: str) -> None:
     with open(class_file, "w", encoding="utf-8") as file:
-        class_details["setDefault"] = _set_default
+        class_details["set_default"] = _set_default
         templates = files("cimgen.languages.python.templates")
         with templates.joinpath(template_filename).open(encoding="utf-8") as f:
             args = {

--- a/cimgen/languages/python/lang_pack.py
+++ b/cimgen/languages/python/lang_pack.py
@@ -23,23 +23,9 @@ def setup(output_path: str, cgmes_profile_details: list[dict], cim_namespace: st
     _create_cgmes_profile(output_path, cgmes_profile_details, cim_namespace)
 
 
-def location(version: str) -> str:
-    return "cimpy." + version + ".Base"
-
-
-base = {"base_class": "Base", "class_location": location}
-
 # These are the files that are used to generate the python files.
 template_files = [{"filename": "cimpy_class_template.mustache", "ext": ".py"}]
 profile_template_files = [{"filename": "cimpy_cgmesProfile_template.mustache", "ext": ".py"}]
-
-
-def get_class_location(class_name: str, class_map: dict, version: str) -> str:
-    # Check if the current class has a parent class
-    if class_map[class_name].subclass_of() and class_map[class_name].subclass_of() in class_map:
-        return "cimpy." + version + "." + class_map[class_name].subclass_of()
-    return location(version)
-
 
 partials = {}
 
@@ -68,6 +54,17 @@ def _set_default(text: str, render: Callable[[str], str]) -> str:
     else:
         # everything else should be a float
         return "0.0"
+
+
+def get_base_class() -> str:
+    return "Base"
+
+
+def get_class_location(class_name: str, class_map: dict, version: str) -> str:
+    # Check if the current class has a parent class
+    if class_map[class_name].subclass_of() and class_map[class_name].subclass_of() in class_map:
+        return "cimpy." + version + "." + class_map[class_name].subclass_of()
+    return "cimpy." + version + ".Base"
 
 
 def run_template(output_path: str, class_details: dict) -> None:

--- a/cimgen/languages/python/templates/cimpy_class_template.mustache
+++ b/cimgen/languages/python/templates/cimpy_class_template.mustache
@@ -1,13 +1,13 @@
-from .{{sub_class_of}} import {{sub_class_of}}
+from .{{subclass_of}} import {{subclass_of}}
 from .CGMESProfile import Profile
 
 
-class {{class_name}}({{sub_class_of}}):
+class {{class_name}}({{subclass_of}}):
     """
     {{{class_comment}}}
 
 {{#attributes}}
-    :{{label}}: {{{comment}}} Default: {{#setDefault}}{{dataType}}{{/setDefault}}
+    :{{label}}: {{{comment}}} Default: {{#set_default}}{{datatype}}{{/set_default}}
 {{/attributes}}
     """
 
@@ -23,10 +23,10 @@ class {{class_name}}({{sub_class_of}}):
     recommendedClassProfile = Profile.{{recommended_class_profile}}.value
 
 {{#super_init}}
-    __doc__ += "\nDocumentation of parent class {{sub_class_of}}:\n" + {{sub_class_of}}.__doc__
+    __doc__ += "\nDocumentation of parent class {{subclass_of}}:\n" + {{subclass_of}}.__doc__
 {{/super_init}}
 
-    def __init__(self{{#attributes}}, {{label}} = {{#setDefault}}{{dataType}}{{/setDefault}}{{/attributes}}{{#super_init}}, *args, **kw_args{{/super_init}}):
+    def __init__(self{{#attributes}}, {{label}} = {{#set_default}}{{datatype}}{{/set_default}}{{/attributes}}{{#super_init}}, *args, **kw_args{{/super_init}}):
 {{#super_init}}
         super().__init__(*args, **kw_args)
 {{/super_init}}


### PR DESCRIPTION
Type annotations make the code easier to understand. It can also be checked with pyright. (Suggestion: check with pyright in pre-commit workflow.)
- Add type annotations to cimgen and all lang_pack.py
- Remove unused functions
- Fix and improve comments 
- Fix ruff warnings for modernpython
- Unify use of partials for cpp, rename lang_pack to langPack
- Rename functions, parameters and variables to fix sonar issues
- Add function get_base_class to all lang_pack.py (replacing dictionary base and function location)
- Simplified template file handling for java, javascript and python