### PR TITLE
fix recursion error when printing python object

### DIFF
--- a/cimgen/languages/python/templates/cimpy_class_template.mustache
+++ b/cimgen/languages/python/templates/cimpy_class_template.mustache
@@ -42,5 +42,5 @@ class {{class_name}}({{subclass_of}}):
         str = "class={{class_name}}\n"
         attributes = self.__dict__
         for key in attributes.keys():
-            str = str + key + "={}\n".format(attributes[key])
+            str = str + key + "={}\n".format(repr(attributes[key]))
         return str


### PR DESCRIPTION
This PR fixes the recursion error when printing a python CGMES object imported by cimpy as described in https://github.com/sogno-platform/cimpy/issues/10.
