### PR TITLE
Fix custom namespaces for modernpython

### DIFF
--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -420,7 +420,7 @@ def _write_all_files(
 ) -> None:
 
     # Setup called only once: make output directory, create base class, create profile class, etc.
-    lang_pack.setup(output_path, _get_profile_details(package_listed_by_short_name), _get_used_namespaces())
+    lang_pack.setup(output_path, version, _get_profile_details(package_listed_by_short_name), _get_used_namespaces())
 
     recommended_class_profiles = _get_recommended_class_profiles(elem_dict)
 

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -9,7 +9,9 @@ from typing import Callable
 # This just makes sure we have somewhere to write the classes.
 # cgmes_profile_details contains index, names and uris for each profile.
 # We use that to create the header data for the profiles.
-def setup(output_path: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]) -> None:
+def setup(
+    output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]
+) -> None:  # NOSONAR
     source_dir = Path(__file__).parent
     dest_dir = Path(output_path)
     for file in dest_dir.glob("**/*.[ch]*"):

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -10,7 +10,9 @@ from typing import Callable
 # cgmes_profile_details contains index, names and uris for each profile.
 # We don't use that here because we aren't exporting into
 # separate profiles.
-def setup(output_path: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]) -> None:  # NOSONAR
+def setup(
+    output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]
+) -> None:  # NOSONAR
     source_dir = Path(__file__).parent
     dest_dir = Path(output_path)
     for file in dest_dir.glob("**/*.java"):
@@ -20,7 +22,7 @@ def setup(output_path: str, cgmes_profile_details: list[dict], namespaces: dict[
         dest_file = dest_dir / file.relative_to(source_dir)
         dest_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(file, dest_file)
-    _create_constants(dest_dir, namespaces)
+    _create_constants(dest_dir, version, namespaces)
 
 
 # These are the files that are used to generate the java files.
@@ -80,10 +82,10 @@ def _write_templated_file(class_file: Path, class_details: dict, template_filena
         file.write(output)
 
 
-def _create_constants(output_path: Path, namespaces: dict[str, str]) -> None:
+def _create_constants(output_path: Path, version: str, namespaces: dict[str, str]) -> None:
     class_file = output_path / ("CimConstants" + constants_template_file["ext"])
     namespaces_list = [{"ns": ns, "uri": uri} for ns, uri in sorted(namespaces.items())]
-    class_details = {"namespaces": namespaces_list}
+    class_details = {"version": version, "namespaces": namespaces_list}
     _write_templated_file(class_file, class_details, constants_template_file["filename"])
 
 

--- a/cimgen/languages/java/templates/java_constants.mustache
+++ b/cimgen/languages/java/templates/java_constants.mustache
@@ -11,6 +11,11 @@ import java.util.Map;
 public final class CimConstants {
 
     /**
+     * CIM version string.
+     */
+    public static final java.lang.String CIM_VERSION = "{{version}}";
+
+    /**
      * Default namespaces used by CGMES. Map of namespace key to URL.
      */
     public static final Map<java.lang.String, java.lang.String> NAMESPACES_MAP;

--- a/cimgen/languages/javascript/lang_pack.py
+++ b/cimgen/languages/javascript/lang_pack.py
@@ -8,7 +8,9 @@ from importlib.resources import files
 # This function makes sure we have somewhere to write the classes.
 # cgmes_profile_details contains index, names and uris for each profile.
 # We use that to create the header data for the profiles.
-def setup(output_path: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]) -> None:
+def setup(
+    output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]
+) -> None:  # NOSONAR
     if not os.path.exists(output_path):
         os.makedirs(output_path)
     else:

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -88,14 +88,6 @@ def _get_python_type(datatype: str) -> str:
         return "float"
 
 
-def _set_imports(attributes: list[dict]) -> list[str]:
-    import_set = set()
-    for attribute in attributes:
-        if attribute["is_datatype_attribute"] or attribute["is_primitive_attribute"]:
-            import_set.add(attribute["attribute_class"])
-    return sorted(import_set)
-
-
 def _set_datatype_attributes(attributes: list[dict]) -> dict:
     datatype_attributes = {}
     datatype_attributes["python_type"] = "None"
@@ -137,7 +129,6 @@ def run_template(output_path: str, class_details: dict) -> None:
         template = class_template_file
         class_details["set_default"] = _set_default
         class_details["set_type"] = _set_type
-        class_details["imports"] = _set_imports(class_details["attributes"])
     resource_file = _create_file(output_path, class_details, template)
     _write_templated_file(resource_file, class_details, template["filename"])
 

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 # creates a couple of files the python implementation needs.
 # cgmes_profile_details contains index, names and uris for each profile.
 # We use that to create the header data for the profiles.
-def setup(
-    output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]
-) -> None:  # NOSONAR
+def setup(output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]) -> None:
     source_dir = Path(__file__).parent
     dest_dir = Path(output_path)
     for file in dest_dir.glob("**/*.[mp]*"):
@@ -26,7 +24,7 @@ def setup(
         dest_file = dest_dir / file.relative_to(source_dir)
         dest_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(file, dest_file)
-    _create_constants(dest_dir, namespaces)
+    _create_constants(dest_dir, version, namespaces)
     _create_cgmes_profile(dest_dir, cgmes_profile_details)
 
 
@@ -164,10 +162,10 @@ def _write_templated_file(class_file: Path, class_details: dict, template_filena
         file.write(output)
 
 
-def _create_constants(output_path: Path, namespaces: dict[str, str]) -> None:
+def _create_constants(output_path: Path, version: str, namespaces: dict[str, str]) -> None:
     class_file = output_path / "utils" / ("constants" + constants_template_file["ext"])
     namespaces_list = [{"ns": ns, "uri": uri} for ns, uri in sorted(namespaces.items())]
-    class_details = {"namespaces": namespaces_list}
+    class_details = {"version": version, "namespaces": namespaces_list}
     _write_templated_file(class_file, class_details, constants_template_file["filename"])
 
 

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 # creates a couple of files the python implementation needs.
 # cgmes_profile_details contains index, names and uris for each profile.
 # We use that to create the header data for the profiles.
-def setup(output_path: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]) -> None:
+def setup(
+    output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]
+) -> None:  # NOSONAR
     source_dir = Path(__file__).parent
     dest_dir = Path(output_path)
     for file in dest_dir.glob("**/*.[mp]*"):

--- a/cimgen/languages/modernpython/lang_pack.py
+++ b/cimgen/languages/modernpython/lang_pack.py
@@ -125,6 +125,16 @@ def run_template(output_path: str, class_details: dict) -> None:
         class_details.update(_set_datatype_attributes(class_details["attributes"]))
     elif class_details["is_an_enum_class"]:
         template = enum_template_file
+        for instance in class_details["enum_instances"]:
+            if "comment" in instance:
+                if instance["label"] in ("cosPhi", "lPerl", "gPerg", "sPers", "HzPerHz", "VPerV", "APerA", "WPerW"):
+                    instance["comment"] += "  # noqa: E501, RUF003"
+                elif instance["label"] in ("l", "I"):
+                    instance["comment"] += "  # noqa: E501, E741"
+                elif instance["label"] == "count":
+                    instance["comment"] += "  # noqa: E501  # type: ignore"
+                else:
+                    instance["comment"] += "  # noqa: E501"
     else:
         template = class_template_file
         class_details["set_default"] = _set_default

--- a/cimgen/languages/modernpython/templates/class_template.mustache
+++ b/cimgen/languages/modernpython/templates/class_template.mustache
@@ -10,9 +10,6 @@ from pydantic.dataclasses import dataclass
 
 from ..utils.profile import BaseProfile, Profile
 from {{class_location}} import {{subclass_of}}
-{{#imports}}
-from .{{.}} import {{.}}
-{{/imports}}
 
 
 @dataclass
@@ -42,10 +39,10 @@ class {{class_name}}({{subclass_of}}):
             "is_list_attribute": {{#is_list_attribute}}True{{/is_list_attribute}}{{^is_list_attribute}}False{{/is_list_attribute}},
             "is_primitive_attribute": {{#is_primitive_attribute}}True{{/is_primitive_attribute}}{{^is_primitive_attribute}}False{{/is_primitive_attribute}},
 {{#is_datatype_attribute}}
-            "attribute_class": {{attribute_class}},
+            "attribute_class": "{{attribute_class}}",
 {{/is_datatype_attribute}}
 {{#is_primitive_attribute}}
-            "attribute_class": {{attribute_class}},
+            "attribute_class": "{{attribute_class}}",
 {{/is_primitive_attribute}}
         },
     )

--- a/cimgen/languages/modernpython/templates/class_template.mustache
+++ b/cimgen/languages/modernpython/templates/class_template.mustache
@@ -35,6 +35,7 @@ class {{class_name}}({{subclass_of}}):
                 {{/attr_origin}}
             ],
             "is_used": {{#is_used}}True{{/is_used}}{{^is_used}}False{{/is_used}},
+            "namespace": "{{attribute_namespace}}",  # NOSONAR
             "is_class_attribute": {{#is_class_attribute}}True{{/is_class_attribute}}{{^is_class_attribute}}False{{/is_class_attribute}},
             "is_datatype_attribute": {{#is_datatype_attribute}}True{{/is_datatype_attribute}}{{^is_datatype_attribute}}False{{/is_datatype_attribute}},
             "is_enum_attribute": {{#is_enum_attribute}}True{{/is_enum_attribute}}{{^is_enum_attribute}}False{{/is_enum_attribute}},

--- a/cimgen/languages/modernpython/templates/constants_template.mustache
+++ b/cimgen/languages/modernpython/templates/constants_template.mustache
@@ -2,7 +2,10 @@
 Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen
 """
 
-# Default namespaces used by CGMES.
+#: CIM version string.
+CIM_VERSION: str = "{{version}}"
+
+#: Default namespaces used by CGMES. Map of namespace key to URL.
 NAMESPACES: dict[str, str] = {  # Those are strings, not real addresses, hence the NOSONAR.
 {{#namespaces}}
     "{{ns}}": "{{uri}}",  # NOSONAR

--- a/cimgen/languages/modernpython/templates/enum_template.mustache
+++ b/cimgen/languages/modernpython/templates/enum_template.mustache
@@ -11,5 +11,5 @@ class {{class_name}}(str, Enum):
     """
 
     {{#enum_instances}}
-    {{label}} = "{{label}}"{{#comment}}  # {{comment}}{{/comment}}  # noqa: E501, E741, RUF003
+    {{label}} = "{{label}}"{{#comment}}  # {{comment}}{{/comment}}
     {{/enum_instances}}

--- a/cimgen/languages/modernpython/utils/base.py
+++ b/cimgen/languages/modernpython/utils/base.py
@@ -23,7 +23,7 @@ class Base:
         A resource can be used by multiple profiles. This is the set of profiles
         where this element can be found.
         """
-        raise NotImplementedError("Method not implemented because not relevant in Base.")
+        return {self.recommended_profile}
 
     @cached_property
     def recommended_profile(self) -> BaseProfile:

--- a/cimgen/languages/modernpython/utils/chevron_writer.py
+++ b/cimgen/languages/modernpython/utils/chevron_writer.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from dataclasses import fields
 from pathlib import Path
+from typing import Any
 
 import chevron
 
@@ -106,7 +107,7 @@ class ChevronWriter:
                     value = attr_infos["value"]
                     attribute_profile = ChevronWriter.get_attribute_profile(obj, attr, class_profile)
                     if value and attr != "mRID" and attribute_profile == profile:
-                        if isinstance(value, (list, tuple)):
+                        if isinstance(value, list | tuple):
                             attributes.extend(attr_infos | {"value": v} for v in value)
                         else:
                             attributes.append(attr_infos)
@@ -190,7 +191,7 @@ class ChevronWriter:
                         infos = {
                             "attr_name": attr_name,
                             "namespace": extra.get("namespace", obj.namespace),
-                            "value": getattr(obj, attr),
+                            "value": ChevronWriter._get_xml_value(getattr(obj, attr)),
                             "is_class_attribute": extra.get("is_class_attribute"),
                             "is_datatype_attribute": extra.get("is_datatype_attribute"),
                             "is_enum_attribute": extra.get("is_enum_attribute"),
@@ -199,3 +200,9 @@ class ChevronWriter:
                         }
                         attr_infos_map[attr] = infos
         return attr_infos_map
+
+    @staticmethod
+    def _get_xml_value(value: Any) -> Any:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return value

--- a/cimgen/languages/modernpython/utils/chevron_writer.py
+++ b/cimgen/languages/modernpython/utils/chevron_writer.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from dataclasses import fields
 from pathlib import Path
 
@@ -142,7 +143,7 @@ class ChevronWriter:
         return obj.recommended_profile
 
     @staticmethod
-    def get_class_profile_map(obj_list: list[Base]) -> dict[str, BaseProfile]:
+    def get_class_profile_map(obj_list: Iterable[Base]) -> dict[str, BaseProfile]:
         """Get the main profiles for a list of CIM objects.
 
         The result could be used as parameter for the functions: write and generate.

--- a/cimgen/languages/modernpython/utils/datatypes.py
+++ b/cimgen/languages/modernpython/utils/datatypes.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from pydantic import Field
 from pydantic.dataclasses import dataclass
@@ -15,8 +15,8 @@ from .profile import BaseProfile
 class Primitive:
     name: str = Field(frozen=True)
     type: object = Field(frozen=True)
+    profiles: list[BaseProfile] = Field(frozen=True)
     namespace: str = Field(frozen=True, default=NAMESPACES["cim"])
-    profiles: List[BaseProfile] = Field(frozen=True)
 
 
 @dataclass(config=cgmes_resource_config)

--- a/cimgen/languages/modernpython/utils/export_template.mustache
+++ b/cimgen/languages/modernpython/utils/export_template.mustache
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<rdf:RDF{{#namespaces}} xmlns:{{key}}="{{url}}"{{/namespaces}}>
+<rdf:RDF{{#namespaces}} xmlns:{{ns}}="{{url}}"{{/namespaces}}>
   {{#model}}
   <md:FullModel rdf:about="{{id}}">
     {{#description}}
@@ -8,45 +8,45 @@
   </md:FullModel>
   {{/model}}
   {{#main}}
-  <cim:{{type}} rdf:ID="{{id}}">
+  <{{ns}}:{{type}} rdf:ID="{{id}}">
     {{#attributes}}
     {{#is_class_attribute}}
-    <cim:{{attr_name}} rdf:resource="#{{value}}" />
+    <{{ns}}:{{attr_name}} rdf:resource="#{{value}}" />
     {{/is_class_attribute}}
     {{#is_datatype_attribute}}
-    <cim:{{attr_name}}>{{value}}</cim:{{attr_name}}>
+    <{{ns}}:{{attr_name}}>{{value}}</{{ns}}:{{attr_name}}>
     {{/is_datatype_attribute}}
     {{#is_enum_attribute}}
-    <cim:{{attr_name}} rdf:resource="{{namespace}}{{value}}" />
+    <{{ns}}:{{attr_name}} rdf:resource="{{namespace}}{{value}}" />
     {{/is_enum_attribute}}
     {{#is_list_attribute}}
-    <cim:{{attr_name}} rdf:resource="#{{value}}" />
+    <{{ns}}:{{attr_name}} rdf:resource="#{{value}}" />
     {{/is_list_attribute}}
     {{#is_primitive_attribute}}
-    <cim:{{attr_name}}>{{value}}</cim:{{attr_name}}>
+    <{{ns}}:{{attr_name}}>{{value}}</{{ns}}:{{attr_name}}>
     {{/is_primitive_attribute}}
     {{/attributes}}
-  </cim:{{type}}>
+  </{{ns}}:{{type}}>
   {{/main}}
   {{#about}}
-  <cim:{{type}} rdf:about="#{{id}}">
+  <{{ns}}:{{type}} rdf:about="#{{id}}">
     {{#attributes}}
     {{#is_class_attribute}}
-    <cim:{{attr_name}} rdf:resource="#{{value}}" />
+    <{{ns}}:{{attr_name}} rdf:resource="#{{value}}" />
     {{/is_class_attribute}}
     {{#is_datatype_attribute}}
-    <cim:{{attr_name}}>{{value}}</cim:{{attr_name}}>
+    <{{ns}}:{{attr_name}}>{{value}}</{{ns}}:{{attr_name}}>
     {{/is_datatype_attribute}}
     {{#is_enum_attribute}}
-    <cim:{{attr_name}} rdf:resource="{{namespace}}{{value}}" />
+    <{{ns}}:{{attr_name}} rdf:resource="{{namespace}}{{value}}" />
     {{/is_enum_attribute}}
     {{#is_list_attribute}}
-    <cim:{{attr_name}} rdf:resource="#{{value}}" />
+    <{{ns}}:{{attr_name}} rdf:resource="#{{value}}" />
     {{/is_list_attribute}}
     {{#is_primitive_attribute}}
-    <cim:{{attr_name}}>{{value}}</cim:{{attr_name}}>
+    <{{ns}}:{{attr_name}}>{{value}}</{{ns}}:{{attr_name}}>
     {{/is_primitive_attribute}}
     {{/attributes}}
-  </cim:{{type}}>
+  </{{ns}}:{{type}}>
   {{/about}}
 </rdf:RDF>

--- a/cimgen/languages/python/lang_pack.py
+++ b/cimgen/languages/python/lang_pack.py
@@ -13,7 +13,9 @@ logger = logging.getLogger(__name__)
 # creates a couple of files the python implementation needs.
 # cgmes_profile_details contains index, names and uris for each profile.
 # We use that to create the header data for the profiles.
-def setup(output_path: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]) -> None:
+def setup(
+    output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]
+) -> None:  # NOSONAR
     if not os.path.exists(output_path):
         os.makedirs(output_path)
     else:


### PR DESCRIPTION
- add attribute_namespace to json_extra to handle custom attributes
- Fix json_dump error by setting attribute_class as str
- Fix type check errors
- Add default implementation of Base.possible_profiles
- Fix type check warnings in chevron_writer.py - see https://github.com/alliander-opensource/pycgmes/pull/39
- Fix output of bool values in chevron_writer.py (in XML true/false only allowed in lower case) - see https://github.com/alliander-opensource/pycgmes/pull/39
- Add handling of namespaces to chevron_writer.py
- Improve handling of ruff and pyright warnings
- Add version to constants.py for modernpython (needed to test custom namespaces in unit tests)