### PR TITLE
Fix custom namespaces for java

### DIFF
--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -220,6 +220,7 @@ class_blacklist = [
     "CIMClassList",
     "CIMFactory",
     "CIMNamespaces",
+    "CimConstants",
     "Factory",
     "Folders",
     "IEC61970",
@@ -227,7 +228,7 @@ class_blacklist = [
     "UnknownType",
 ]
 
-iec61970_blacklist = ["CIMClassList", "CIMNamespaces", "Folders", "Task", "IEC61970"]
+iec61970_blacklist = ["CIMClassList", "CIMNamespaces", "CimConstants", "Folders", "Task", "IEC61970"]
 
 
 def _is_primitive_or_enum_class(file: Path) -> bool:

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -9,9 +9,7 @@ from typing import Callable
 # This just makes sure we have somewhere to write the classes.
 # cgmes_profile_details contains index, names and uris for each profile.
 # We use that to create the header data for the profiles.
-def setup(
-    output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]
-) -> None:  # NOSONAR
+def setup(output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]) -> None:
     source_dir = Path(__file__).parent
     dest_dir = Path(output_path)
     for file in dest_dir.glob("**/*.[ch]*"):
@@ -21,7 +19,8 @@ def setup(
         dest_file = dest_dir / file.relative_to(source_dir)
         dest_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(file, dest_file)
-    _create_cgmes_profile(dest_dir, cgmes_profile_details, namespaces["cim"])
+    _create_constants(dest_dir, version, namespaces)
+    _create_cgmes_profile(dest_dir, cgmes_profile_details)
 
 
 # These are the files that are used to generate the header and object files.
@@ -43,6 +42,10 @@ enum_template_files = [
 string_template_files = [
     {"filename": "cpp_string_header_template.mustache", "ext": ".hpp"},
     {"filename": "cpp_string_object_template.mustache", "ext": ".cpp"},
+]
+constants_template_files = [
+    {"filename": "cpp_constants_header_template.mustache", "ext": ".hpp"},
+    {"filename": "cpp_constants_object_template.mustache", "ext": ".cpp"},
 ]
 profile_template_files = [
     {"filename": "cpp_profile_header_template.mustache", "ext": ".hpp"},
@@ -113,13 +116,18 @@ def _write_templated_file(class_file: Path, class_details: dict, template_filena
         file.write(output)
 
 
-def _create_cgmes_profile(output_path: Path, profile_details: list[dict], cim_namespace: str) -> None:
+def _create_constants(output_path: Path, version: str, namespaces: dict[str, str]) -> None:
+    for template_info in constants_template_files:
+        class_file = output_path / ("CimConstants" + template_info["ext"])
+        namespaces_list = [{"ns": ns, "uri": uri} for ns, uri in sorted(namespaces.items())]
+        class_details = {"version": version, "namespaces": namespaces_list}
+        _write_templated_file(class_file, class_details, template_info["filename"])
+
+
+def _create_cgmes_profile(output_path: Path, profile_details: list[dict]) -> None:
     for template_info in profile_template_files:
         class_file = output_path / ("CGMESProfile" + template_info["ext"])
-        class_details = {
-            "profiles": profile_details,
-            "cim_namespace": cim_namespace,
-        }
+        class_details = {"profiles": profile_details}
         _write_templated_file(class_file, class_details, template_info["filename"])
 
 

--- a/cimgen/languages/cpp/templates/cpp_constants_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_constants_header_template.mustache
@@ -1,0 +1,16 @@
+#ifndef CIM_CONSTANTS_HPP
+#define CIM_CONSTANTS_HPP
+/*
+Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen
+*/
+
+#include <map>
+#include <string>
+
+/** \brief CIM version string. */
+extern const std::string CimVersion;
+
+/** \brief Default namespaces used by CGMES. Map of namespace key to URL. */
+extern const std::map<std::string, std::string> NamespaceMap;
+
+#endif

--- a/cimgen/languages/cpp/templates/cpp_constants_object_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_constants_object_template.mustache
@@ -1,0 +1,13 @@
+/*
+Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen
+*/
+#include "CimConstants.hpp"
+
+const std::string CimVersion = "{{version}}";
+
+const std::map<std::string, std::string> NamespaceMap =
+{
+{{#namespaces}}
+	{ "{{ns}}", "{{uri}}" },
+{{/namespaces}}
+};

--- a/cimgen/languages/cpp/templates/cpp_profile_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_profile_header_template.mustache
@@ -25,6 +25,4 @@ const std::list<std::string>& getProfileURIs(CGMESProfile profile);
 CGMESProfile getProfileFromShortName(const std::string& name);
 CGMESProfile getProfileFromLongName(const std::string& name);
 
-std::string getCimNamespace();
-
 #endif

--- a/cimgen/languages/cpp/templates/cpp_profile_object_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_profile_object_template.mustache
@@ -35,8 +35,6 @@ static const std::map<CGMESProfile, std::list<std::string>> ProfileURIs =
 {{/profiles}}
 };
 
-static const std::string CimNamespace = "{{cim_namespace}}";
-
 const std::list<CGMESProfile>&
 getProfileList()
 {
@@ -101,10 +99,4 @@ getProfileFromLongName(const std::string& name)
 		}
 	}
 	return UnknownProfile;
-}
-
-std::string
-getCimNamespace()
-{
-	return CimNamespace;
 }

--- a/cimgen/languages/java/AttributeInterface.java
+++ b/cimgen/languages/java/AttributeInterface.java
@@ -8,4 +8,5 @@ public interface AttributeInterface {
 	BaseClass getAttribute(java.lang.String attrName);
 	Set<java.lang.String> getAttributeNames();
 	java.lang.String getAttributeFullName(java.lang.String attrName);
+	java.lang.String getAttributeNamespaceUrl(java.lang.String attrName);
 }

--- a/cimgen/languages/java/BaseClass.java
+++ b/cimgen/languages/java/BaseClass.java
@@ -69,4 +69,29 @@ public abstract class BaseClass implements BaseClassInterface, BaseClassBuilder,
 	public java.lang.String toString(boolean topClass) {
 		return "";
 	}
+
+	/**
+	 * Get the namespace URL of an object of this class.
+	 *
+	 * @return The namespace URL
+	 */
+	@Override
+	public java.lang.String getClassNamespaceUrl() {
+		return CimConstants.NAMESPACES_MAP.get("cim");
+	}
+
+	/**
+	 * Get the namespace URL of an attribute (also for inherited attributes).
+	 *
+	 * @return The namespace URL
+	 */
+	@Override
+	public java.lang.String getAttributeNamespaceUrl(java.lang.String attrName) {
+		return CimConstants.NAMESPACES_MAP.get("cim");
+	}
+
+	protected Map<java.lang.String, java.lang.String> allAttrNamespaceMap() {
+		Map<java.lang.String, java.lang.String> map = new LinkedHashMap<>();
+		return map;
+	}
 }

--- a/cimgen/languages/java/BaseClassInterface.java
+++ b/cimgen/languages/java/BaseClassInterface.java
@@ -9,4 +9,5 @@ public interface BaseClassInterface {
 	java.lang.String getRdfid();
 	java.lang.String toString(boolean topClass);
 	java.lang.String debugString();
+	java.lang.String getClassNamespaceUrl();
 }

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -107,7 +107,7 @@ class_blacklist = [
     "BaseClassBuilder",
     "PrimitiveBuilder",
     "BaseClass",
-    "CIMClassList",
+    "CIMClassMap",
     "CimConstants",
     "Logging",
 ]

--- a/cimgen/languages/java/templates/java_class.mustache
+++ b/cimgen/languages/java/templates/java_class.mustache
@@ -213,4 +213,43 @@ public class {{class_name}} extends {{subclass_of}} {
 	public java.lang.String debugString() {
 		return debugName;
 	}
+
+	/**
+	 * Get the namespace URL of an object of this class.
+	 *
+	 * @return The namespace URL
+	 */
+	@Override
+	public java.lang.String getClassNamespaceUrl() {
+		return "{{class_namespace}}";
+	}
+
+	/**
+	 * Get the namespace URL of an attribute (also for inherited attributes).
+	 *
+	 * @return The namespace URL
+	 */
+	@Override
+	public java.lang.String getAttributeNamespaceUrl(java.lang.String attrName) {
+		return ATTR_NAMESPACE_MAP.get(attrName);
+	}
+
+	private static final Map<java.lang.String, java.lang.String> ATTR_NAMESPACE_MAP;
+	static {
+		ATTR_NAMESPACE_MAP = new {{class_name}}().allAttrNamespaceMap();
+	}
+
+	@Override
+	protected Map<java.lang.String, java.lang.String> allAttrNamespaceMap() {
+		Map<java.lang.String, java.lang.String> map = new LinkedHashMap<>(classAttrNamespaceMap);
+		map.putAll(super.allAttrNamespaceMap());
+		map.remove("LAST_ATTRIBUTE");
+		return map;
+	}
+
+	private Map<java.lang.String, java.lang.String> classAttrNamespaceMap = Map.ofEntries(
+{{#attributes}}
+			Map.entry("{{> label}}", "{{attribute_namespace}}"),
+{{/attributes}}
+			Map.entry("LAST_ATTRIBUTE", ""));
 }

--- a/cimgen/languages/java/utils/RdfReader.java
+++ b/cimgen/languages/java/utils/RdfReader.java
@@ -132,7 +132,7 @@ public class RdfReader extends DefaultHandler {
 
 	@Override
 	public void startElement(String namespaceUri, String localName, String qName, Attributes attributes) {
-		if (!qName.startsWith("cim")) {
+		if (qName.startsWith("rdf") || qName.startsWith("md")) {
 			return;
 		}
 
@@ -156,7 +156,7 @@ public class RdfReader extends DefaultHandler {
 					BaseClass object = createOrLinkObject(localName, rdfid);
 					objectStack.push(object);
 				} else {
-					LOG.debug(String.format("Possible class element: %s", qName));
+					LOG.debug(String.format("Possible class element: %s", localName));
 				}
 			}
 			if (qName.equals("rdf:resource")) {

--- a/cimgen/languages/java/utils/RdfWriter.java
+++ b/cimgen/languages/java/utils/RdfWriter.java
@@ -3,9 +3,13 @@ package cim4j.utils;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import cim4j.BaseClass;
 import cim4j.CimConstants;
@@ -52,29 +56,38 @@ public class RdfWriter {
 	 * @return cim data as rdf string
 	 */
 	public String convertCimData() {
-		final String RDF = CimConstants.NAMESPACES_MAP.get("rdf");
-		final String CIM = CimConstants.NAMESPACES_MAP.get("cim");
+		var usedNamespaces = getUsedNamespaces();
 
 		var rdfLines = new StringBuilder();
 		rdfLines.append("<?xml version='1.0' encoding='utf-8' ?>\n");
-		rdfLines.append("<rdf:RDF xmlns:rdf='" + RDF + "' xmlns:cim='" + CIM + "'>\n");
+		rdfLines.append("<rdf:RDF");
+		var nsList = new ArrayList<>(usedNamespaces.keySet());
+		Collections.sort(nsList);
+		for (var ns : nsList) {
+			var url = usedNamespaces.get(ns);
+			rdfLines.append(String.format(" xmlns:%s='%s'", ns, url));
+		}
+		rdfLines.append(">\n");
 
 		int count = 0;
 		for (String rdfid : cimData.keySet()) {
 			BaseClass cimObj = cimData.get(rdfid);
-			if (!cimObj.getClass().equals(IdentifiedObject.class)) {
+			var nsObj = getNamespaceKey(cimObj.getClassNamespaceUrl());
+			if (nsObj != null && !cimObj.getClass().equals(IdentifiedObject.class)) {
 				String cimType = cimObj.debugString();
-				rdfLines.append(String.format("  <cim:%s rdf:ID='%s'>\n", cimType, rdfid));
+				rdfLines.append(String.format("  <%s:%s rdf:ID='%s'>\n", nsObj, cimType, rdfid));
 				var attrNames = cimObj.getAttributeNames();
 				for (String attrName : attrNames) {
+					var namespaceUrl = cimObj.getAttributeNamespaceUrl(attrName);
+					var nsAttr = getNamespaceKey(namespaceUrl);
 					String attrFullName = cimObj.getAttributeFullName(attrName);
 					var attrObj = cimObj.getAttribute(attrName);
 					if (attrObj != null) {
 						if (attrObj.isPrimitive()) {
 							var value = attrObj.getValue();
 							if (value != null) {
-								rdfLines.append(String.format("    <cim:%s>%s</cim:%s>\n", attrFullName,
-										value, attrFullName));
+								rdfLines.append(String.format("    <%s:%s>%s</%s:%s>\n", nsAttr, attrFullName,
+										value, nsAttr, attrFullName));
 							} else {
 								LOG.error(String.format("No value for attribute %s of %s(%s)", attrFullName, cimType,
 										rdfid));
@@ -82,11 +95,13 @@ public class RdfWriter {
 						} else {
 							String attrRdfId = attrObj.getRdfid();
 							if (attrRdfId != null) {
-								if (!attrRdfId.contains("#")) {
+								if (attrRdfId.contains("#")) {
+									attrRdfId = namespaceUrl + attrRdfId.split("#")[1];
+								} else {
 									attrRdfId = "#" + attrRdfId;
 								}
-								rdfLines.append(String.format("    <cim:%s rdf:resource='%s' />\n",
-										attrFullName, attrRdfId));
+								rdfLines.append(String.format("    <%s:%s rdf:resource='%s' />\n",
+										nsAttr, attrFullName, attrRdfId));
 							} else {
 								LOG.error(String.format("No rdfid for attribute %s of %s(%s)", attrFullName, cimType,
 										rdfid));
@@ -94,7 +109,7 @@ public class RdfWriter {
 						}
 					}
 				}
-				rdfLines.append(String.format("  </cim:%s>\n", cimType));
+				rdfLines.append(String.format("  </%s:%s>\n", nsObj, cimType));
 				++count;
 			}
 		}
@@ -118,5 +133,38 @@ public class RdfWriter {
 			LOG.error(txt, ex);
 			throw new RuntimeException(txt, ex);
 		}
+	}
+
+	private Map<java.lang.String, java.lang.String> getUsedNamespaces() {
+		Set<java.lang.String> urls = new HashSet<>();
+		urls.add(CimConstants.NAMESPACES_MAP.get("rdf"));
+		for (String rdfid : cimData.keySet()) {
+			BaseClass cimObj = cimData.get(rdfid);
+			urls.add(cimObj.getClassNamespaceUrl());
+			var attrNames = cimObj.getAttributeNames();
+			for (String attrName : attrNames) {
+				var attrObj = cimObj.getAttribute(attrName);
+				if (attrObj != null) {
+					urls.add(cimObj.getAttributeNamespaceUrl(attrName));
+				}
+			}
+		}
+		Map<java.lang.String, java.lang.String> namespaces = new HashMap<>();
+		for (var url : urls) {
+			var ns = getNamespaceKey(url);
+			if (ns != null) {
+				namespaces.put(ns, url);
+			}
+		}
+		return namespaces;
+	}
+
+	private java.lang.String getNamespaceKey(java.lang.String url) {
+		for (var entry : CimConstants.NAMESPACES_MAP.entrySet()) {
+			if (entry.getValue().equals(url)) {
+				return entry.getKey();
+			}
+		}
+		return null;
 	}
 }

--- a/cimgen/languages/javascript/lang_pack.py
+++ b/cimgen/languages/javascript/lang_pack.py
@@ -8,21 +8,21 @@ from importlib.resources import files
 # This function makes sure we have somewhere to write the classes.
 # cgmes_profile_details contains index, names and uris for each profile.
 # We use that to create the header data for the profiles.
-def setup(
-    output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]
-) -> None:  # NOSONAR
+def setup(output_path: str, version: str, cgmes_profile_details: list[dict], namespaces: dict[str, str]) -> None:
     if not os.path.exists(output_path):
         os.makedirs(output_path)
     else:
         for filename in os.listdir(output_path):
             os.remove(os.path.join(output_path, filename))
     _create_base(output_path)
-    _create_cgmes_profile(output_path, cgmes_profile_details, namespaces["cim"])
+    _create_constants(output_path, version, namespaces)
+    _create_cgmes_profile(output_path, cgmes_profile_details)
 
 
 # These are the files that are used to generate the javascript files.
 template_file = {"filename": "handlebars_template.mustache", "ext": ".js"}
 base_template_file = {"filename": "handlebars_baseclass_template.mustache", "ext": ".js"}
+constants_template_file = {"filename": "handlebars_constants_template.mustache", "ext": ".js"}
 profile_template_file = {"filename": "handlebars_profile_template.mustache", "ext": ".js"}
 
 partials = {}
@@ -141,12 +141,16 @@ def _create_base(output_path: str) -> None:
     _write_templated_file(class_file, {}, base_template_file["filename"])
 
 
-def _create_cgmes_profile(output_path: str, profile_details: list[dict], cim_namespace: str) -> None:
+def _create_constants(output_path: str, version: str, namespaces: dict[str, str]) -> None:
+    class_file = os.path.join(output_path, "CimConstants" + constants_template_file["ext"])
+    namespaces_list = [{"ns": ns, "uri": uri} for ns, uri in sorted(namespaces.items())]
+    class_details = {"version": version, "namespaces": namespaces_list}
+    _write_templated_file(class_file, class_details, constants_template_file["filename"])
+
+
+def _create_cgmes_profile(output_path: str, profile_details: list[dict]) -> None:
     class_file = os.path.join(output_path, "CGMESProfile" + profile_template_file["ext"])
-    class_details = {
-        "profiles": profile_details,
-        "cim_namespace": cim_namespace,
-    }
+    class_details = {"profiles": profile_details}
     _write_templated_file(class_file, class_details, profile_template_file["filename"])
 
 

--- a/cimgen/languages/javascript/templates/handlebars_constants_template.mustache
+++ b/cimgen/languages/javascript/templates/handlebars_constants_template.mustache
@@ -1,0 +1,18 @@
+/*
+Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen
+*/
+
+class CimConstants {
+
+    // CIM version string.
+    static const cimVersion = "{{version}}";
+
+    // Default namespaces used by CGMES. Map of namespace key to URL.
+    static namespaces = {  // Those are strings, not real addresses, hence the NOSONAR.
+{{#namespaces}}
+        "{{ns}}": {{uri}},  // NOSONAR
+{{/namespaces}}
+    };
+}
+
+export default CimConstants

--- a/cimgen/languages/javascript/templates/handlebars_profile_template.mustache
+++ b/cimgen/languages/javascript/templates/handlebars_profile_template.mustache
@@ -1,3 +1,6 @@
+/*
+Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen
+*/
 
 class CGMESProfile {
     static profileUrls = {  // Those are strings, not real addresses, hence the NOSONAR.
@@ -17,5 +20,3 @@ class CGMESProfile {
 }
 
 export default CGMESProfile
-
-export const CIM_NAMESPACE = "{{cim_namespace}}"  // NOSONAR

--- a/cimgen/languages/python/templates/cimpy_constants_template.mustache
+++ b/cimgen/languages/python/templates/cimpy_constants_template.mustache
@@ -1,0 +1,13 @@
+"""
+Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen
+"""
+
+#: CIM version string.
+CIM_VERSION: str = "{{version}}"
+
+#: Default namespaces used by CGMES. Map of namespace key to URL.
+NAMESPACES: dict[str, str] = {  # Those are strings, not real addresses, hence the NOSONAR.
+{{#namespaces}}
+    "{{ns}}": "{{uri}}",  # NOSONAR
+{{/namespaces}}
+}

--- a/cimgen/languages/python/templates/cimpy_profile_template.mustache
+++ b/cimgen/languages/python/templates/cimpy_profile_template.mustache
@@ -1,3 +1,7 @@
+"""
+Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen
+"""
+
 from enum import Enum
 
 
@@ -39,6 +43,3 @@ class Profile(Enum):
     @classmethod
     def from_long_name(cls, long_name):
         return cls[short_profile_name[long_name]]
-
-
-cim_namespace = "{{cim_namespace}}"  # NOSONAR


### PR DESCRIPTION
- Fix custom namespace in java writer (e.g. "entsoe" in CGMES2, "eu" in CGMES3; using new generated functions getClassNamespaceUrl and getAttributeNamespaceUrl)
- Add version to setup parameters to write it to CimConstants.java (needed to test custom namespaces in unit tests)
- Fix custom namespace in java reader (e.g. entsoe in CGMES2, eu in CGMES3)
- Add version to constants.py for modernpython (needed to test custom namespaces in unit tests)
- Add creation of constants for cpp, generating all namespaces in CimConstants.hpp/cpp; add version to constants for cpp (needed to test custom namespaces in unit tests); remove getCimNamespace() from CGMESProfile.hpp/cpp (use NamespaceMap.at("cim") from CimConstants now)
- Add creation of constants for python, generating all namespaces in CimConstants.py; add version to constants for python (needed to test custom namespaces in unit tests); remove cim_namespace from CGMESProfile.py (use NAMESPACES["cim"] from CimConstants now)
- Add creation of constants for javascript, generating all namespaces in CimConstants.js; add version to constants for javascript (needed to test custom namespaces in unit tests); remove CIM_NAMESPACE from CGMESProfile.js (use CimConstants.namespaces["cim"] from CimConstants now)