### PR TITLE
Fix long parse time in java reader

### DIFF
--- a/cimgen/languages/java/AttributeInterface.java
+++ b/cimgen/languages/java/AttributeInterface.java
@@ -3,10 +3,16 @@ package cim4j;
 import java.util.Set;
 
 public interface AttributeInterface {
-	void setAttribute(java.lang.String attrName, BaseClass value);
-	void setAttribute(java.lang.String attrName, java.lang.String value);
-	BaseClass getAttribute(java.lang.String attrName);
-	Set<java.lang.String> getAttributeNames();
-	java.lang.String getAttributeFullName(java.lang.String attrName);
-	java.lang.String getAttributeNamespaceUrl(java.lang.String attrName);
+
+    void setAttribute(java.lang.String attrName, BaseClass value);
+
+    void setAttribute(java.lang.String attrName, java.lang.String value);
+
+    BaseClass getAttribute(java.lang.String attrName);
+
+    Set<java.lang.String> getAttributeNames();
+
+    java.lang.String getAttributeFullName(java.lang.String attrName);
+
+    java.lang.String getAttributeNamespaceUrl(java.lang.String attrName);
 }

--- a/cimgen/languages/java/BaseClass.java
+++ b/cimgen/languages/java/BaseClass.java
@@ -7,91 +7,91 @@ import java.util.Set;
 
 public abstract class BaseClass implements BaseClassInterface, BaseClassBuilder, AttributeInterface {
 
-	private static final Logging LOG = Logging.getLogger(BaseClass.class);
+    private static final Logging LOG = Logging.getLogger(BaseClass.class);
 
-	@Override
-	public boolean isPrimitive() {
-		return false;
-	}
+    @Override
+    public boolean isPrimitive() {
+        return false;
+    }
 
-	@Override
-	public boolean isInitialized() {
-		return false;
-	}
+    @Override
+    public boolean isInitialized() {
+        return false;
+    }
 
-	@Override
-	public Object getValue() {
-		return null;
-	}
+    @Override
+    public Object getValue() {
+        return null;
+    }
 
-	@Override
-	public void setRdfid(java.lang.String id) {
-		LOG.error("Shouldn't have instantiated an abstract class: " + id);
-	}
+    @Override
+    public void setRdfid(java.lang.String id) {
+        LOG.error("Shouldn't have instantiated an abstract class: " + id);
+    }
 
-	@Override
-	public java.lang.String getRdfid() {
-		return null;
-	}
+    @Override
+    public java.lang.String getRdfid() {
+        return null;
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, BaseClass value) {
-		LOG.error("No-one knows what to do with the attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, BaseClass value) {
+        LOG.error("No-one knows what to do with the attribute: " + attrName);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, java.lang.String value) {
-		LOG.error("No-one knows what to do with the attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, java.lang.String value) {
+        LOG.error("No-one knows what to do with the attribute: " + attrName);
+    }
 
-	@Override
-	public BaseClass getAttribute(java.lang.String attrName) {
-		return null;
-	}
+    @Override
+    public BaseClass getAttribute(java.lang.String attrName) {
+        return null;
+    }
 
-	protected Map<java.lang.String, java.lang.String> getAttributeNamesMap() {
-		Map<java.lang.String, java.lang.String> namesMap = new LinkedHashMap<>();
-		return namesMap;
-	}
+    protected Map<java.lang.String, java.lang.String> getAttributeNamesMap() {
+        Map<java.lang.String, java.lang.String> namesMap = new LinkedHashMap<>();
+        return namesMap;
+    }
 
-	@Override
-	public Set<java.lang.String> getAttributeNames() {
-		LinkedHashSet<java.lang.String> attrNames = new LinkedHashSet<>();
-		return attrNames;
-	}
+    @Override
+    public Set<java.lang.String> getAttributeNames() {
+        LinkedHashSet<java.lang.String> attrNames = new LinkedHashSet<>();
+        return attrNames;
+    }
 
-	@Override
-	public java.lang.String getAttributeFullName(java.lang.String attrName) {
-		return null;
-	}
+    @Override
+    public java.lang.String getAttributeFullName(java.lang.String attrName) {
+        return null;
+    }
 
-	@Override
-	public java.lang.String toString(boolean topClass) {
-		return "";
-	}
+    @Override
+    public java.lang.String toString(boolean topClass) {
+        return "";
+    }
 
-	/**
-	 * Get the namespace URL of an object of this class.
-	 *
-	 * @return The namespace URL
-	 */
-	@Override
-	public java.lang.String getClassNamespaceUrl() {
-		return CimConstants.NAMESPACES_MAP.get("cim");
-	}
+    /**
+     * Get the namespace URL of an object of this class.
+     *
+     * @return The namespace URL
+     */
+    @Override
+    public java.lang.String getClassNamespaceUrl() {
+        return CimConstants.NAMESPACES_MAP.get("cim");
+    }
 
-	/**
-	 * Get the namespace URL of an attribute (also for inherited attributes).
-	 *
-	 * @return The namespace URL
-	 */
-	@Override
-	public java.lang.String getAttributeNamespaceUrl(java.lang.String attrName) {
-		return CimConstants.NAMESPACES_MAP.get("cim");
-	}
+    /**
+     * Get the namespace URL of an attribute (also for inherited attributes).
+     *
+     * @return The namespace URL
+     */
+    @Override
+    public java.lang.String getAttributeNamespaceUrl(java.lang.String attrName) {
+        return CimConstants.NAMESPACES_MAP.get("cim");
+    }
 
-	protected Map<java.lang.String, java.lang.String> allAttrNamespaceMap() {
-		Map<java.lang.String, java.lang.String> map = new LinkedHashMap<>();
-		return map;
-	}
+    protected Map<java.lang.String, java.lang.String> allAttrNamespaceMap() {
+        Map<java.lang.String, java.lang.String> map = new LinkedHashMap<>();
+        return map;
+    }
 }

--- a/cimgen/languages/java/BaseClassBuilder.java
+++ b/cimgen/languages/java/BaseClassBuilder.java
@@ -1,5 +1,6 @@
 package cim4j;
 
 public interface BaseClassBuilder {
-	BaseClass construct();
+
+    BaseClass construct();
 }

--- a/cimgen/languages/java/BaseClassInterface.java
+++ b/cimgen/languages/java/BaseClassInterface.java
@@ -1,13 +1,22 @@
 package cim4j;
 
 public interface BaseClassInterface {
-	boolean isPrimitive();
-	boolean isInitialized();
-	void setValue(java.lang.String s);
-	Object getValue();
-	void setRdfid(java.lang.String id);
-	java.lang.String getRdfid();
-	java.lang.String toString(boolean topClass);
-	java.lang.String debugString();
-	java.lang.String getClassNamespaceUrl();
+
+    boolean isPrimitive();
+
+    boolean isInitialized();
+
+    void setValue(java.lang.String s);
+
+    Object getValue();
+
+    void setRdfid(java.lang.String id);
+
+    java.lang.String getRdfid();
+
+    java.lang.String toString(boolean topClass);
+
+    java.lang.String debugString();
+
+    java.lang.String getClassNamespaceUrl();
 }

--- a/cimgen/languages/java/Boolean.java
+++ b/cimgen/languages/java/Boolean.java
@@ -5,68 +5,68 @@ package cim4j;
  */
 public class Boolean extends BaseClass {
 
-	private boolean value = false;
+    private boolean value = false;
 
-	private boolean initialized = false;
+    private boolean initialized = false;
 
-	public Boolean() {
-	}
+    public Boolean() {
+    }
 
-	public Boolean(boolean v) {
-		value = v;
-		initialized = true;
-	}
+    public Boolean(boolean v) {
+        value = v;
+        initialized = true;
+    }
 
-	public Boolean(java.lang.String s) {
-		setValue(s);
-	}
+    public Boolean(java.lang.String s) {
+        setValue(s);
+    }
 
-	@Override
-	public BaseClass construct() {
-		return new Boolean();
-	}
+    @Override
+    public BaseClass construct() {
+        return new Boolean();
+    }
 
-	@Override
-	public boolean isPrimitive() {
-		return true;
-	}
+    @Override
+    public boolean isPrimitive() {
+        return true;
+    }
 
-	@Override
-	public boolean isInitialized() {
-		return initialized;
-	}
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
-	@Override
-	public void setValue(java.lang.String s) {
-		java.lang.String s_ignore_case = s.toLowerCase();
-		value = (s_ignore_case.equals("true"));
-		initialized = true;
-	}
+    @Override
+    public void setValue(java.lang.String s) {
+        java.lang.String s_ignore_case = s.toLowerCase();
+        value = (s_ignore_case.equals("true"));
+        initialized = true;
+    }
 
-	@Override
-	public Object getValue() {
-		return java.lang.Boolean.valueOf(value);
-	}
+    @Override
+    public Object getValue() {
+        return java.lang.Boolean.valueOf(value);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, BaseClass value) {
-		throw new IllegalArgumentException("Boolean class cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, BaseClass value) {
+        throw new IllegalArgumentException("Boolean class cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, java.lang.String value) {
-		throw new IllegalArgumentException("Boolean class cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, java.lang.String value) {
+        throw new IllegalArgumentException("Boolean class cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public java.lang.String toString(boolean topClass) {
-		return java.lang.Boolean.toString(value);
-	}
+    @Override
+    public java.lang.String toString(boolean topClass) {
+        return java.lang.Boolean.toString(value);
+    }
 
-	private final java.lang.String debugName = "Boolean";
+    private final java.lang.String debugName = "Boolean";
 
-	@Override
-	public java.lang.String debugString() {
-		return debugName;
-	}
+    @Override
+    public java.lang.String debugString() {
+        return debugName;
+    }
 }

--- a/cimgen/languages/java/Integer.java
+++ b/cimgen/languages/java/Integer.java
@@ -5,73 +5,73 @@ package cim4j;
  */
 public class Integer extends BaseClass {
 
-	private static final Logging LOG = Logging.getLogger(Integer.class);
+    private static final Logging LOG = Logging.getLogger(Integer.class);
 
-	private int value = 0;
+    private int value = 0;
 
-	private boolean initialized = false;
+    private boolean initialized = false;
 
-	public Integer() {
-	}
+    public Integer() {
+    }
 
-	public Integer(int v) {
-		value = v;
-		initialized = true;
-	}
+    public Integer(int v) {
+        value = v;
+        initialized = true;
+    }
 
-	public Integer(java.lang.String s) {
-		setValue(s);
-	}
+    public Integer(java.lang.String s) {
+        setValue(s);
+    }
 
-	@Override
-	public BaseClass construct() {
-		return new Integer();
-	}
+    @Override
+    public BaseClass construct() {
+        return new Integer();
+    }
 
-	@Override
-	public boolean isPrimitive() {
-		return true;
-	}
+    @Override
+    public boolean isPrimitive() {
+        return true;
+    }
 
-	@Override
-	public boolean isInitialized() {
-		return initialized;
-	}
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
-	@Override
-	public void setValue(java.lang.String s) {
-		try {
-			value = java.lang.Integer.parseInt(s.trim());
-			initialized = true;
-		} catch (NumberFormatException nfe) {
-			LOG.error("NumberFormatException: " + nfe.getMessage());
-		}
-	}
+    @Override
+    public void setValue(java.lang.String s) {
+        try {
+            value = java.lang.Integer.parseInt(s.trim());
+            initialized = true;
+        } catch (NumberFormatException nfe) {
+            LOG.error("NumberFormatException: " + nfe.getMessage());
+        }
+    }
 
-	@Override
-	public Object getValue() {
-		return java.lang.Integer.valueOf(value);
-	}
+    @Override
+    public Object getValue() {
+        return java.lang.Integer.valueOf(value);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, BaseClass value) {
-		throw new IllegalArgumentException("Integer class cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, BaseClass value) {
+        throw new IllegalArgumentException("Integer class cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, java.lang.String value) {
-		throw new IllegalArgumentException("Integer class cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, java.lang.String value) {
+        throw new IllegalArgumentException("Integer class cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public java.lang.String toString(boolean topClass) {
-		return java.lang.Integer.toString(value);
-	}
+    @Override
+    public java.lang.String toString(boolean topClass) {
+        return java.lang.Integer.toString(value);
+    }
 
-	private final java.lang.String debugName = "Integer";
+    private final java.lang.String debugName = "Integer";
 
-	@Override
-	public java.lang.String debugString() {
-		return debugName;
-	}
+    @Override
+    public java.lang.String debugString() {
+        return debugName;
+    }
 }

--- a/cimgen/languages/java/Logging.java
+++ b/cimgen/languages/java/Logging.java
@@ -10,185 +10,185 @@ package cim4j;
  * lines and set printlnEnabled = false.
  */
 public class Logging {
-	public enum Level {
-		fatal,
-		error,
-		warn,
-		info,
-		debug,
-		trace
-	}
+    public enum Level {
+        fatal,
+        error,
+        warn,
+        info,
+        debug,
+        trace
+    }
 
-	private Level level;
-	private java.lang.String className;
-	// private Logger log4jLogger;
-	private static boolean log4jEnabled = true;
-	private static boolean printlnEnabled = true;
+    private Level level;
+    private java.lang.String className;
+    // private Logger log4jLogger;
+    private static boolean log4jEnabled = true;
+    private static boolean printlnEnabled = true;
 
-	private Logging(final Class<?> clazz, Level logLevel) {
-		level = logLevel;
-		className = clazz.getName();
-		// log4jLogger = LogManager.getLogger(clazz);
-	}
+    private Logging(final Class<?> clazz, Level logLevel) {
+        level = logLevel;
+        className = clazz.getName();
+        // log4jLogger = LogManager.getLogger(clazz);
+    }
 
-	private void log(Level logLevel, java.lang.String message) {
-		if (printlnEnabled && logLevel.compareTo(level) <= 0) {
-			System.out.println(className + " " + logLevel + ": " + message);
-		}
-	}
+    private void log(Level logLevel, java.lang.String message) {
+        if (printlnEnabled && logLevel.compareTo(level) <= 0) {
+            System.out.println(className + " " + logLevel + ": " + message);
+        }
+    }
 
-	/**
-	 * Returns a Logger using the fully qualified name of the Class as the Logger
-	 * name.
-	 *
-	 * @param clazz The Class whose name should be used as the Logger name.
-	 */
-	public static Logging getLogger(final Class<?> clazz) {
-		return new Logging(clazz, Level.error);
-	}
+    /**
+     * Returns a Logger using the fully qualified name of the Class as the Logger
+     * name.
+     *
+     * @param clazz The Class whose name should be used as the Logger name.
+     */
+    public static Logging getLogger(final Class<?> clazz) {
+        return new Logging(clazz, Level.error);
+    }
 
-	/**
-	 * Returns a Logger using the fully qualified name of the Class as the Logger
-	 * name.
-	 *
-	 * @param clazz The Class whose name should be used as the Logger name.
-	 * @param level Log level.
-	 */
-	public static Logging getLogger(final Class<?> clazz, Level level) {
-		return new Logging(clazz, level);
-	}
+    /**
+     * Returns a Logger using the fully qualified name of the Class as the Logger
+     * name.
+     *
+     * @param clazz The Class whose name should be used as the Logger name.
+     * @param level Log level.
+     */
+    public static Logging getLogger(final Class<?> clazz, Level level) {
+        return new Logging(clazz, level);
+    }
 
-	/**
-	 * Is logging enabled?
-	 *
-	 * @return logging enabled?
-	 */
-	public static boolean isEnabled() {
-		// return log4jEnabled;
-		return printlnEnabled;
-	}
+    /**
+     * Is logging enabled?
+     *
+     * @return logging enabled?
+     */
+    public static boolean isEnabled() {
+        // return log4jEnabled;
+        return printlnEnabled;
+    }
 
-	/**
-	 * Enable or disable logging - for unit tests.
-	 *
-	 * @param enabled logging enabled
-	 */
-	public static void setEnabled(boolean enabled) {
-		log4jEnabled = enabled;
-		printlnEnabled = enabled;
-	}
+    /**
+     * Enable or disable logging - for unit tests.
+     *
+     * @param enabled logging enabled
+     */
+    public static void setEnabled(boolean enabled) {
+        log4jEnabled = enabled;
+        printlnEnabled = enabled;
+    }
 
-	/**
-	 * Logs a message object with the FATAL level.
-	 *
-	 * @param message the message string to log.
-	 */
-	public void fatal(java.lang.String message) {
-		if (log4jEnabled) {
-			// log4jLogger.fatal(message);
-		}
-		log(Level.fatal, message);
-	}
+    /**
+     * Logs a message object with the FATAL level.
+     *
+     * @param message the message string to log.
+     */
+    public void fatal(java.lang.String message) {
+        if (log4jEnabled) {
+            // log4jLogger.fatal(message);
+        }
+        log(Level.fatal, message);
+    }
 
-	/**
-	 * Logs a message object with the ERROR level.
-	 *
-	 * @param message the message string to log.
-	 */
-	public void error(java.lang.String message) {
-		if (log4jEnabled) {
-			// log4jLogger.error(message);
-		}
-		log(Level.error, message);
-	}
+    /**
+     * Logs a message object with the ERROR level.
+     *
+     * @param message the message string to log.
+     */
+    public void error(java.lang.String message) {
+        if (log4jEnabled) {
+            // log4jLogger.error(message);
+        }
+        log(Level.error, message);
+    }
 
-	/**
-	 * Logs a message object with the WARN level.
-	 *
-	 * @param message the message string to log.
-	 */
-	public void warn(java.lang.String message) {
-		if (log4jEnabled) {
-			// log4jLogger.warn(message);
-		}
-		log(Level.warn, message);
-	}
+    /**
+     * Logs a message object with the WARN level.
+     *
+     * @param message the message string to log.
+     */
+    public void warn(java.lang.String message) {
+        if (log4jEnabled) {
+            // log4jLogger.warn(message);
+        }
+        log(Level.warn, message);
+    }
 
-	/**
-	 * Logs a message object with the INFO level.
-	 *
-	 * @param message the message string to log.
-	 */
-	public void info(java.lang.String message) {
-		if (log4jEnabled) {
-			// log4jLogger.info(message);
-		}
-		log(Level.info, message);
-	}
+    /**
+     * Logs a message object with the INFO level.
+     *
+     * @param message the message string to log.
+     */
+    public void info(java.lang.String message) {
+        if (log4jEnabled) {
+            // log4jLogger.info(message);
+        }
+        log(Level.info, message);
+    }
 
-	/**
-	 * Logs a message object with the DEBUG level.
-	 *
-	 * @param message the message string to log.
-	 */
-	public void debug(java.lang.String message) {
-		if (log4jEnabled) {
-			// log4jLogger.debug(message);
-		}
-		log(Level.debug, message);
-	}
+    /**
+     * Logs a message object with the DEBUG level.
+     *
+     * @param message the message string to log.
+     */
+    public void debug(java.lang.String message) {
+        if (log4jEnabled) {
+            // log4jLogger.debug(message);
+        }
+        log(Level.debug, message);
+    }
 
-	/**
-	 * Logs a message object with the TRACE level.
-	 *
-	 * @param message the message string to log.
-	 */
-	public void trace(java.lang.String message) {
-		if (log4jEnabled) {
-			// log4jLogger.trace(message);
-		}
-		log(Level.trace, message);
-	}
+    /**
+     * Logs a message object with the TRACE level.
+     *
+     * @param message the message string to log.
+     */
+    public void trace(java.lang.String message) {
+        if (log4jEnabled) {
+            // log4jLogger.trace(message);
+        }
+        log(Level.trace, message);
+    }
 
-	/**
-	 * Logs a message object with the FATAL level including the stack trace of the
-	 * {@link Throwable} <code>throwable</code> passed as parameter.
-	 *
-	 * @param message   the message CharSequence to log.
-	 * @param throwable the {@code Throwable} to log, including its stack trace.
-	 */
-	public void fatal(java.lang.String message, Throwable throwable) {
-		if (log4jEnabled) {
-			// log4jLogger.fatal(message, throwable);
-		}
-		log(Level.fatal, message + " Exception:" + throwable.getMessage());
-	}
+    /**
+     * Logs a message object with the FATAL level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    public void fatal(java.lang.String message, Throwable throwable) {
+        if (log4jEnabled) {
+            // log4jLogger.fatal(message, throwable);
+        }
+        log(Level.fatal, message + " Exception:" + throwable.getMessage());
+    }
 
-	/**
-	 * Logs a message object with the ERROR level including the stack trace of the
-	 * {@link Throwable} <code>throwable</code> passed as parameter.
-	 *
-	 * @param message   the message CharSequence to log.
-	 * @param throwable the {@code Throwable} to log, including its stack trace.
-	 */
-	public void error(java.lang.String message, Throwable throwable) {
-		if (log4jEnabled) {
-			// log4jLogger.error(message, throwable);
-		}
-		log(Level.error, message + " Exception:" + throwable.getMessage());
-	}
+    /**
+     * Logs a message object with the ERROR level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    public void error(java.lang.String message, Throwable throwable) {
+        if (log4jEnabled) {
+            // log4jLogger.error(message, throwable);
+        }
+        log(Level.error, message + " Exception:" + throwable.getMessage());
+    }
 
-	/**
-	 * Logs a message object with the WARN level including the stack trace of the
-	 * {@link Throwable} <code>throwable</code> passed as parameter.
-	 *
-	 * @param message   the message CharSequence to log.
-	 * @param throwable the {@code Throwable} to log, including its stack trace.
-	 */
-	public void warn(java.lang.String message, Throwable throwable) {
-		if (log4jEnabled) {
-			// log4jLogger.warn(message, throwable);
-		}
-		log(Level.warn, message + " Exception:" + throwable.getMessage());
-	}
+    /**
+     * Logs a message object with the WARN level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    public void warn(java.lang.String message, Throwable throwable) {
+        if (log4jEnabled) {
+            // log4jLogger.warn(message, throwable);
+        }
+        log(Level.warn, message + " Exception:" + throwable.getMessage());
+    }
 }

--- a/cimgen/languages/java/PrimitiveBuilder.java
+++ b/cimgen/languages/java/PrimitiveBuilder.java
@@ -1,5 +1,6 @@
 package cim4j;
 
 public interface PrimitiveBuilder {
-	BaseClass construct(java.lang.String value);
+
+    BaseClass construct(java.lang.String value);
 }

--- a/cimgen/languages/java/main/Main.java
+++ b/cimgen/languages/java/main/Main.java
@@ -15,104 +15,104 @@ import cim4j.utils.RdfWriter;
  */
 public final class Main {
 
-	private static final Logging LOG = Logging.getLogger(Main.class);
+    private static final Logging LOG = Logging.getLogger(Main.class);
 
-	// Private dummy constructor - prevent to instantiate the class at all
-	private Main() {
-	}
+    // Private dummy constructor - prevent to instantiate the class at all
+    private Main() {
+    }
 
-	private static void printUsageAndExit(String aError) {
-		if (!aError.isEmpty()) {
-			System.out.println("\nError: " + aError);
-		}
-		System.out.println("\nRead rdf files and write the data to one rdf file.\n");
-		System.out.println("Usage: java -jar cim4j.jar <rdf_file>  [<rdf_file>  ...] <rdf_file>");
-		System.exit(2);
-	}
+    private static void printUsageAndExit(String aError) {
+        if (!aError.isEmpty()) {
+            System.out.println("\nError: " + aError);
+        }
+        System.out.println("\nRead rdf files and write the data to one rdf file.\n");
+        System.out.println("Usage: java -jar cim4j.jar <rdf_file>  [<rdf_file>  ...] <rdf_file>");
+        System.exit(2);
+    }
 
-	/**
-	 * Main function of the cim4j application.
-	 */
-	public static void main(String[] aArgs) {
-		if (aArgs.length < 2) {
-			printUsageAndExit("too few arguments");
-		}
+    /**
+     * Main function of the cim4j application.
+     */
+    public static void main(String[] aArgs) {
+        if (aArgs.length < 2) {
+            printUsageAndExit("too few arguments");
+        }
 
-		List<String> inputFiles = new ArrayList<>();
-		for (int idx = 0; idx < aArgs.length - 1; ++idx) {
-			inputFiles.add(aArgs[idx]);
-		}
-		String outputFile = aArgs[aArgs.length - 1];
+        List<String> inputFiles = new ArrayList<>();
+        for (int idx = 0; idx < aArgs.length - 1; ++idx) {
+            inputFiles.add(aArgs[idx]);
+        }
+        String outputFile = aArgs[aArgs.length - 1];
 
-		checkArgs(inputFiles, outputFile);
+        checkArgs(inputFiles, outputFile);
 
-		readRdfWriteRdf(inputFiles, outputFile);
-	}
+        readRdfWriteRdf(inputFiles, outputFile);
+    }
 
-	/**
-	 * Read cim data from rdf files, write the data to a rdf file.
-	 *
-	 * @param inputFiles list of paths of files to read
-	 * @param outputFile path of file to write
-	 */
-	public static void readRdfWriteRdf(List<String> inputFiles, String outputFile) {
-		var cimData = readRdf(inputFiles);
-		if (cimData != null) {
-			writeRdf(outputFile, cimData);
-		}
-	}
+    /**
+     * Read cim data from rdf files, write the data to a rdf file.
+     *
+     * @param inputFiles list of paths of files to read
+     * @param outputFile path of file to write
+     */
+    public static void readRdfWriteRdf(List<String> inputFiles, String outputFile) {
+        var cimData = readRdf(inputFiles);
+        if (cimData != null) {
+            writeRdf(outputFile, cimData);
+        }
+    }
 
-	/**
-	 * Read the cim data from rdf files.
-	 *
-	 * @param inputFiles list of paths of files to read
-	 * @return cim data as map of rdfid to cim object
-	 */
-	public static Map<String, BaseClass> readRdf(List<String> inputFiles) {
-		var allCimData = new LinkedHashMap<String, BaseClass>();
-		try {
-			for (String rdfFile : inputFiles) {
-				LOG.info("Read RDF file: " + rdfFile);
-				var cimData = RdfReader.read(rdfFile);
-				allCimData.putAll(cimData);
-			}
-		} catch (Exception ex) {
-			LOG.error("Failed to convert RDF files to CIM", ex);
-			return null;
-		}
-		return allCimData;
-	}
+    /**
+     * Read the cim data from rdf files.
+     *
+     * @param inputFiles list of paths of files to read
+     * @return cim data as map of rdfid to cim object
+     */
+    public static Map<String, BaseClass> readRdf(List<String> inputFiles) {
+        var allCimData = new LinkedHashMap<String, BaseClass>();
+        try {
+            for (String rdfFile : inputFiles) {
+                LOG.info("Read RDF file: " + rdfFile);
+                var cimData = RdfReader.read(rdfFile);
+                allCimData.putAll(cimData);
+            }
+        } catch (Exception ex) {
+            LOG.error("Failed to convert RDF files to CIM", ex);
+            return null;
+        }
+        return allCimData;
+    }
 
-	/**
-	 * Write cim data to a rdf file.
-	 *
-	 * @param outputFile path of file to write
-	 * @param cimData cim data as map of rdfid to cim object
-	 */
-	public static void writeRdf(String outputFile, Map<String, BaseClass> cimData) {
-		try {
-			var writer = new RdfWriter();
-			writer.addCimData(cimData);
-			writer.write(outputFile);
-		} catch (Exception ex) {
-			LOG.error("Failed to write CIM data to a RDF file", ex);
-			return;
-		}
-	}
+    /**
+     * Write cim data to a rdf file.
+     *
+     * @param outputFile path of file to write
+     * @param cimData    cim data as map of rdfid to cim object
+     */
+    public static void writeRdf(String outputFile, Map<String, BaseClass> cimData) {
+        try {
+            var writer = new RdfWriter();
+            writer.addCimData(cimData);
+            writer.write(outputFile);
+        } catch (Exception ex) {
+            LOG.error("Failed to write CIM data to a RDF file", ex);
+            return;
+        }
+    }
 
-	private static void checkArgs(List<String> inputFiles, String outputFile) {
-		for (String inputFile : inputFiles) {
-			if (!isRdfFile(inputFile)) {
-				printUsageAndExit(inputFile + " is not a rdf file");
-			}
-		}
-		if (!isRdfFile(outputFile)) {
-			printUsageAndExit(outputFile + " is not a rdf file");
-		}
-	}
+    private static void checkArgs(List<String> inputFiles, String outputFile) {
+        for (String inputFile : inputFiles) {
+            if (!isRdfFile(inputFile)) {
+                printUsageAndExit(inputFile + " is not a rdf file");
+            }
+        }
+        if (!isRdfFile(outputFile)) {
+            printUsageAndExit(outputFile + " is not a rdf file");
+        }
+    }
 
-	private static boolean isRdfFile(String fileName) {
-		String file = fileName.toLowerCase();
-		return file.endsWith(".rdf") || file.endsWith(".xml");
-	}
+    private static boolean isRdfFile(String fileName) {
+        String file = fileName.toLowerCase();
+        return file.endsWith(".rdf") || file.endsWith(".xml");
+    }
 }

--- a/cimgen/languages/java/main/Main.java
+++ b/cimgen/languages/java/main/Main.java
@@ -93,7 +93,7 @@ public final class Main {
 		try {
 			var writer = new RdfWriter();
 			writer.addCimData(cimData);
-			writer.writeCimData(outputFile);
+			writer.write(outputFile);
 		} catch (Exception ex) {
 			LOG.error("Failed to write CIM data to a RDF file", ex);
 			return;

--- a/cimgen/languages/java/main/Main.java
+++ b/cimgen/languages/java/main/Main.java
@@ -1,7 +1,6 @@
 package cim4j.main;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,18 +68,12 @@ public final class Main {
      * @return cim data as map of rdfid to cim object
      */
     public static Map<String, BaseClass> readRdf(List<String> inputFiles) {
-        var allCimData = new LinkedHashMap<String, BaseClass>();
         try {
-            for (String rdfFile : inputFiles) {
-                LOG.info("Read RDF file: " + rdfFile);
-                var cimData = RdfReader.read(rdfFile);
-                allCimData.putAll(cimData);
-            }
+            return RdfReader.read(inputFiles);
         } catch (Exception ex) {
             LOG.error("Failed to convert RDF files to CIM", ex);
             return null;
         }
-        return allCimData;
     }
 
     /**

--- a/cimgen/languages/java/templates/java_class.mustache
+++ b/cimgen/languages/java/templates/java_class.mustache
@@ -15,241 +15,241 @@ import java.util.Set;
 {{/class_comment}}
 public class {{class_name}} extends {{subclass_of}} {
 
-	private static final Logging LOG = Logging.getLogger({{class_name}}.class);
+    private static final Logging LOG = Logging.getLogger({{class_name}}.class);
 
-	private BaseClass[] {{class_name}}_class_attributes;
-	private BaseClass[] {{class_name}}_primitive_attributes;
-	private java.lang.String rdfid;
+    private BaseClass[] {{class_name}}_class_attributes;
+    private BaseClass[] {{class_name}}_primitive_attributes;
+    private java.lang.String rdfid;
 
-	private static final Map<java.lang.String, java.lang.String> ATTRIBUTE_NAMES_MAP;
-	static {
-		ATTRIBUTE_NAMES_MAP = new {{class_name}}().getAttributeNamesMap();
-	}
+    private static final Map<java.lang.String, java.lang.String> ATTRIBUTE_NAMES_MAP;
+    static {
+        ATTRIBUTE_NAMES_MAP = new {{class_name}}().getAttributeNamesMap();
+    }
 
-	private enum {{class_name}}_primitive_builder implements PrimitiveBuilder {
+    private enum {{class_name}}_primitive_builder implements PrimitiveBuilder {
 {{#attributes}}
 {{#is_primitive_attribute}}
-		{{> label}}() {
-			public BaseClass construct(java.lang.String value) {
-				return new {{attribute_class}}(value);
-			}
-		},
+        {{> label}}() {
+            public BaseClass construct(java.lang.String value) {
+                return new {{attribute_class}}(value);
+            }
+        },
 {{/is_primitive_attribute}}
 {{#is_datatype_attribute}}
-		{{> label}}() {
-			public BaseClass construct(java.lang.String value) {
-				return new {{attribute_class}}(value);
-			}
-		},
+        {{> label}}() {
+            public BaseClass construct(java.lang.String value) {
+                return new {{attribute_class}}(value);
+            }
+        },
 {{/is_datatype_attribute}}
 {{#is_enum_attribute}}
-		{{> label}}() {
-			public BaseClass construct(java.lang.String value) {
-				return new {{attribute_class}}(value);
-			}
-		},
+        {{> label}}() {
+            public BaseClass construct(java.lang.String value) {
+                return new {{attribute_class}}(value);
+            }
+        },
 {{/is_enum_attribute}}
 {{/attributes}}
-		LAST_ENUM() {
-			public BaseClass construct(java.lang.String value) {
-				return new Integer("0");
-			}
-		}
-	}
+        LAST_ENUM() {
+            public BaseClass construct(java.lang.String value) {
+                return new Integer("0");
+            }
+        }
+    }
 
-	private enum {{class_name}}_class_attributes_enum {
+    private enum {{class_name}}_class_attributes_enum {
 {{#attributes}}
-		{{> label}},
+        {{> label}},
 {{/attributes}}
-		LAST_ENUM
-	}
+        LAST_ENUM
+    }
 
-	public {{class_name}}() {
-		{{class_name}}_primitive_attributes = new BaseClass[{{class_name}}_primitive_builder.values().length];
-		{{class_name}}_class_attributes = new BaseClass[{{class_name}}_class_attributes_enum.values().length];
-	}
+    public {{class_name}}() {
+        {{class_name}}_primitive_attributes = new BaseClass[{{class_name}}_primitive_builder.values().length];
+        {{class_name}}_class_attributes = new BaseClass[{{class_name}}_class_attributes_enum.values().length];
+    }
 
-	@Override
-	public BaseClass construct() {
-		return new {{class_name}}();
-	}
+    @Override
+    public BaseClass construct() {
+        return new {{class_name}}();
+    }
 
-	@Override
-	public void setValue(java.lang.String s) {
-		LOG.error(debugString() + " is not sure what to do with " + s);
-	}
+    @Override
+    public void setValue(java.lang.String s) {
+        LOG.error(debugString() + " is not sure what to do with " + s);
+    }
 
-	@Override
-	public void setRdfid(java.lang.String id) {
-		rdfid = id;
-	}
+    @Override
+    public void setRdfid(java.lang.String id) {
+        rdfid = id;
+    }
 
-	@Override
-	public java.lang.String getRdfid() {
-		return rdfid;
-	}
+    @Override
+    public java.lang.String getRdfid() {
+        return rdfid;
+    }
 
-	private void updateAttributeInArray({{class_name}}_class_attributes_enum attrEnum, BaseClass value) {
-		try {
-			{{class_name}}_class_attributes[attrEnum.ordinal()] = value;
-		} catch (ArrayIndexOutOfBoundsException aoobe) {
-			LOG.error("No such attribute: " + attrEnum.name() + ": " + aoobe.getMessage());
-		}
-	}
+    private void updateAttributeInArray({{class_name}}_class_attributes_enum attrEnum, BaseClass value) {
+        try {
+            {{class_name}}_class_attributes[attrEnum.ordinal()] = value;
+        } catch (ArrayIndexOutOfBoundsException aoobe) {
+            LOG.error("No such attribute: " + attrEnum.name() + ": " + aoobe.getMessage());
+        }
+    }
 
-	private void updateAttributeInArray({{class_name}}_primitive_builder attrEnum, BaseClass value) {
-		try {
-			{{class_name}}_primitive_attributes[attrEnum.ordinal()] = value;
-		} catch (ArrayIndexOutOfBoundsException aoobe) {
-			LOG.error("No such attribute: " + attrEnum.name() + ": " + aoobe.getMessage());
-		}
-	}
+    private void updateAttributeInArray({{class_name}}_primitive_builder attrEnum, BaseClass value) {
+        try {
+            {{class_name}}_primitive_attributes[attrEnum.ordinal()] = value;
+        } catch (ArrayIndexOutOfBoundsException aoobe) {
+            LOG.error("No such attribute: " + attrEnum.name() + ": " + aoobe.getMessage());
+        }
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, BaseClass value) {
-		try {
-			{{class_name}}_class_attributes_enum attrEnum = {{class_name}}_class_attributes_enum.valueOf(attrName);
-			updateAttributeInArray(attrEnum, value);
-			LOG.debug("Updated {{class_name}}, setting " + attrName);
-		} catch (IllegalArgumentException iae) {
-			super.setAttribute(attrName, value);
-		}
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, BaseClass value) {
+        try {
+            {{class_name}}_class_attributes_enum attrEnum = {{class_name}}_class_attributes_enum.valueOf(attrName);
+            updateAttributeInArray(attrEnum, value);
+            LOG.debug("Updated {{class_name}}, setting " + attrName);
+        } catch (IllegalArgumentException iae) {
+            super.setAttribute(attrName, value);
+        }
+    }
 
-	@Override
-	/* If the attribute is a String, it is a primitive and we will make it into a BaseClass */
-	public void setAttribute(java.lang.String attrName, java.lang.String value) {
-		try {
-			{{class_name}}_primitive_builder attrEnum = {{class_name}}_primitive_builder.valueOf(attrName);
-			updateAttributeInArray(attrEnum, attrEnum.construct(value));
-			LOG.debug("Updated {{class_name}}, setting " + attrName + " to: " + value);
-		} catch (IllegalArgumentException iae) {
-			super.setAttribute(attrName, value);
-		}
-	}
+    @Override
+    /* If the attribute is a String, it is a primitive and we will make it into a BaseClass */
+    public void setAttribute(java.lang.String attrName, java.lang.String value) {
+        try {
+            {{class_name}}_primitive_builder attrEnum = {{class_name}}_primitive_builder.valueOf(attrName);
+            updateAttributeInArray(attrEnum, attrEnum.construct(value));
+            LOG.debug("Updated {{class_name}}, setting " + attrName + " to: " + value);
+        } catch (IllegalArgumentException iae) {
+            super.setAttribute(attrName, value);
+        }
+    }
 
-	@Override
-	public BaseClass getAttribute(java.lang.String attrName) {
-		boolean defined = false;
-		try {
-			{{class_name}}_primitive_builder attrEnum = {{class_name}}_primitive_builder.valueOf(attrName);
-			defined = true;
-			BaseClass attrValue = {{class_name}}_primitive_attributes[attrEnum.ordinal()];
-			if (attrValue != null) {
-				return attrValue;
-			}
-		} catch (IllegalArgumentException ignored) {
-		}
+    @Override
+    public BaseClass getAttribute(java.lang.String attrName) {
+        boolean defined = false;
+        try {
+            {{class_name}}_primitive_builder attrEnum = {{class_name}}_primitive_builder.valueOf(attrName);
+            defined = true;
+            BaseClass attrValue = {{class_name}}_primitive_attributes[attrEnum.ordinal()];
+            if (attrValue != null) {
+                return attrValue;
+            }
+        } catch (IllegalArgumentException ignored) {
+        }
 
-		try {
-			{{class_name}}_class_attributes_enum attrEnum = {{class_name}}_class_attributes_enum.valueOf(attrName);
-			defined = true;
-			BaseClass attrValue = {{class_name}}_class_attributes[attrEnum.ordinal()];
-			if (attrValue != null) {
-				return attrValue;
-			}
-		} catch (IllegalArgumentException ignored) {
-		}
+        try {
+            {{class_name}}_class_attributes_enum attrEnum = {{class_name}}_class_attributes_enum.valueOf(attrName);
+            defined = true;
+            BaseClass attrValue = {{class_name}}_class_attributes[attrEnum.ordinal()];
+            if (attrValue != null) {
+                return attrValue;
+            }
+        } catch (IllegalArgumentException ignored) {
+        }
 
-		if (!defined) {
-			return super.getAttribute(attrName);
-		}
-		return null;
-	}
+        if (!defined) {
+            return super.getAttribute(attrName);
+        }
+        return null;
+    }
 
-	@Override
-	protected Map<java.lang.String, java.lang.String> getAttributeNamesMap() {
-		Map<java.lang.String, java.lang.String> namesMap = new LinkedHashMap<>();
-		for (var enumValue : {{class_name}}_primitive_builder.values()) {
-			if (enumValue != {{class_name}}_primitive_builder.LAST_ENUM) {
-				namesMap.put(enumValue.name(), "{{class_name}}." + enumValue.name());
-			}
-		}
-		for (var enumValue : {{class_name}}_class_attributes_enum.values()) {
-			if (enumValue != {{class_name}}_class_attributes_enum.LAST_ENUM) {
-				namesMap.put(enumValue.name(), "{{class_name}}." + enumValue.name());
-			}
-		}
-		namesMap.putAll(super.getAttributeNamesMap());
-		return namesMap;
-	}
+    @Override
+    protected Map<java.lang.String, java.lang.String> getAttributeNamesMap() {
+        Map<java.lang.String, java.lang.String> namesMap = new LinkedHashMap<>();
+        for (var enumValue : {{class_name}}_primitive_builder.values()) {
+            if (enumValue != {{class_name}}_primitive_builder.LAST_ENUM) {
+                namesMap.put(enumValue.name(), "{{class_name}}." + enumValue.name());
+            }
+        }
+        for (var enumValue : {{class_name}}_class_attributes_enum.values()) {
+            if (enumValue != {{class_name}}_class_attributes_enum.LAST_ENUM) {
+                namesMap.put(enumValue.name(), "{{class_name}}." + enumValue.name());
+            }
+        }
+        namesMap.putAll(super.getAttributeNamesMap());
+        return namesMap;
+    }
 
-	@Override
-	public Set<java.lang.String> getAttributeNames() {
-		return ATTRIBUTE_NAMES_MAP.keySet();
-	}
+    @Override
+    public Set<java.lang.String> getAttributeNames() {
+        return ATTRIBUTE_NAMES_MAP.keySet();
+    }
 
-	@Override
-	public java.lang.String getAttributeFullName(java.lang.String attrName) {
-		return ATTRIBUTE_NAMES_MAP.get(attrName);
-	}
+    @Override
+    public java.lang.String getAttributeFullName(java.lang.String attrName) {
+        return ATTRIBUTE_NAMES_MAP.get(attrName);
+    }
 
-	@Override
-	public java.lang.String toString(boolean topClass) {
-		java.lang.String result = "";
-		if (topClass) {
-			for ({{class_name}}_primitive_builder attrEnum : {{class_name}}_primitive_builder.values()) {
-				BaseClass bc = {{class_name}}_primitive_attributes[attrEnum.ordinal()];
-				if (bc != null) {
-					result += "    {{class_name}}." + attrEnum.name() + "(" + bc.debugString() + ")" + " " + bc.toString(false) + System.lineSeparator();
-				}
-			}
-			for ({{class_name}}_class_attributes_enum attrEnum : {{class_name}}_class_attributes_enum.values()) {
-				BaseClass bc = {{class_name}}_class_attributes[attrEnum.ordinal()];
-				if (bc != null) {
-					result += "    {{class_name}}." + attrEnum.name() + "(" + bc.debugString() + ")" + " " + bc.toString(false) + System.lineSeparator();
-				}
-			}
-			result += super.toString(true);
-		} else {
-			result += "({{class_name}}) RDFID: " + rdfid;
-		}
-		return result;
-	}
+    @Override
+    public java.lang.String toString(boolean topClass) {
+        java.lang.String result = "";
+        if (topClass) {
+            for ({{class_name}}_primitive_builder attrEnum : {{class_name}}_primitive_builder.values()) {
+                BaseClass bc = {{class_name}}_primitive_attributes[attrEnum.ordinal()];
+                if (bc != null) {
+                    result += "    {{class_name}}." + attrEnum.name() + "(" + bc.debugString() + ")" + " " + bc.toString(false) + System.lineSeparator();
+                }
+            }
+            for ({{class_name}}_class_attributes_enum attrEnum : {{class_name}}_class_attributes_enum.values()) {
+                BaseClass bc = {{class_name}}_class_attributes[attrEnum.ordinal()];
+                if (bc != null) {
+                    result += "    {{class_name}}." + attrEnum.name() + "(" + bc.debugString() + ")" + " " + bc.toString(false) + System.lineSeparator();
+                }
+            }
+            result += super.toString(true);
+        } else {
+            result += "({{class_name}}) RDFID: " + rdfid;
+        }
+        return result;
+    }
 
-	private final java.lang.String debugName = "{{class_name}}";
+    private final java.lang.String debugName = "{{class_name}}";
 
-	@Override
-	public java.lang.String debugString() {
-		return debugName;
-	}
+    @Override
+    public java.lang.String debugString() {
+        return debugName;
+    }
 
-	/**
-	 * Get the namespace URL of an object of this class.
-	 *
-	 * @return The namespace URL
-	 */
-	@Override
-	public java.lang.String getClassNamespaceUrl() {
-		return "{{class_namespace}}";
-	}
+    /**
+     * Get the namespace URL of an object of this class.
+     *
+     * @return The namespace URL
+     */
+    @Override
+    public java.lang.String getClassNamespaceUrl() {
+        return "{{class_namespace}}";
+    }
 
-	/**
-	 * Get the namespace URL of an attribute (also for inherited attributes).
-	 *
-	 * @return The namespace URL
-	 */
-	@Override
-	public java.lang.String getAttributeNamespaceUrl(java.lang.String attrName) {
-		return ATTR_NAMESPACE_MAP.get(attrName);
-	}
+    /**
+     * Get the namespace URL of an attribute (also for inherited attributes).
+     *
+     * @return The namespace URL
+     */
+    @Override
+    public java.lang.String getAttributeNamespaceUrl(java.lang.String attrName) {
+        return ATTR_NAMESPACE_MAP.get(attrName);
+    }
 
-	private static final Map<java.lang.String, java.lang.String> ATTR_NAMESPACE_MAP;
-	static {
-		ATTR_NAMESPACE_MAP = new {{class_name}}().allAttrNamespaceMap();
-	}
+    private static final Map<java.lang.String, java.lang.String> ATTR_NAMESPACE_MAP;
+    static {
+        ATTR_NAMESPACE_MAP = new {{class_name}}().allAttrNamespaceMap();
+    }
 
-	@Override
-	protected Map<java.lang.String, java.lang.String> allAttrNamespaceMap() {
-		Map<java.lang.String, java.lang.String> map = new LinkedHashMap<>(classAttrNamespaceMap);
-		map.putAll(super.allAttrNamespaceMap());
-		map.remove("LAST_ATTRIBUTE");
-		return map;
-	}
+    @Override
+    protected Map<java.lang.String, java.lang.String> allAttrNamespaceMap() {
+        Map<java.lang.String, java.lang.String> map = new LinkedHashMap<>(classAttrNamespaceMap);
+        map.putAll(super.allAttrNamespaceMap());
+        map.remove("LAST_ATTRIBUTE");
+        return map;
+    }
 
-	private Map<java.lang.String, java.lang.String> classAttrNamespaceMap = Map.ofEntries(
+    private Map<java.lang.String, java.lang.String> classAttrNamespaceMap = Map.ofEntries(
 {{#attributes}}
-			Map.entry("{{> label}}", "{{attribute_namespace}}"),
+            Map.entry("{{> label}}", "{{attribute_namespace}}"),
 {{/attributes}}
-			Map.entry("LAST_ATTRIBUTE", ""));
+            Map.entry("LAST_ATTRIBUTE", ""));
 }

--- a/cimgen/languages/java/templates/java_classlist.mustache
+++ b/cimgen/languages/java/templates/java_classlist.mustache
@@ -1,0 +1,60 @@
+/*
+Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cimgen
+*/
+
+package cim4j;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public final class CimClassMap {
+
+    /**
+     * Checks if the class name is known as CIM class.
+     *
+     * @param className The class name to check.
+     * @return          Is this a CIM class?
+     */
+    public static boolean isCimClass(java.lang.String className) {
+        return CREATE_MAP.containsKey(className);
+    }
+
+    /**
+     * Creates a new CIM object.
+     *
+     * @param className The class name of the new CIM object.
+     * @return          The new CIM object.
+     */
+    public static BaseClass createCimObject(java.lang.String className) {
+        var createFunction = CREATE_MAP.get(className);
+        return createFunction.get();
+    }
+
+    /**
+     * Creates a new CIM object (as object of the correct class).
+     *
+     * @param clazz The class of the new CIM object.
+     * @return      The new CIM object.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends BaseClass> T createCimObject(Class<T> clazz) {
+        var className = clazz.getSimpleName();
+        return (T) createCimObject(className);
+    }
+
+    /**
+     * Map of CIM class name to supplier function which creates a new CIM object.
+     */
+    private static final Map<java.lang.String, Supplier<BaseClass>> CREATE_MAP;
+    static {
+        var map = new LinkedHashMap<java.lang.String, Supplier<BaseClass>>();
+
+{{#classes}}
+        map.put("{{.}}", () -> new {{.}}());
+{{/classes}}
+
+        CREATE_MAP = Collections.unmodifiableMap(map);
+    }
+}

--- a/cimgen/languages/java/templates/java_enum.mustache
+++ b/cimgen/languages/java/templates/java_enum.mustache
@@ -11,80 +11,80 @@ package cim4j;
 {{/class_comment}}
 public class {{class_name}} extends BaseClass {
 
-	private static final Logging LOG = Logging.getLogger({{class_name}}.class);
+    private static final Logging LOG = Logging.getLogger({{class_name}}.class);
 
-	private enum {{class_name}}_ENUM {
+    private enum {{class_name}}_ENUM {
 {{#enum_instances}}
 {{#comment}}
-		/**
-		 * {{comment}}
-		 */
+        /**
+         * {{comment}}
+         */
 {{/comment}}
-		{{label}},
+        {{label}},
 {{/enum_instances}}
-		MAX_{{class_name}}_ENUM
-	}
+        MAX_{{class_name}}_ENUM
+    }
 
-	private {{class_name}}_ENUM value;
+    private {{class_name}}_ENUM value;
 
-	private boolean initialized = false;
+    private boolean initialized = false;
 
-	public {{class_name}}() {
-	}
+    public {{class_name}}() {
+    }
 
-	public {{class_name}}(java.lang.String s) {
-		setValue(s);
-	}
+    public {{class_name}}(java.lang.String s) {
+        setValue(s);
+    }
 
-	@Override
-	public BaseClass construct() {
-		return new {{class_name}}();
-	}
+    @Override
+    public BaseClass construct() {
+        return new {{class_name}}();
+    }
 
-	@Override
-	public boolean isPrimitive() {
-		return true;
-	}
+    @Override
+    public boolean isPrimitive() {
+        return true;
+    }
 
-	@Override
-	public boolean isInitialized() {
-		return initialized;
-	}
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
-	@Override
-	public void setValue(java.lang.String s) {
-		try {
-			value = {{class_name}}_ENUM.valueOf(s.trim());
-			initialized = true;
-		} catch (IllegalArgumentException iae) {
-			LOG.error("IllegalArgumentException: " + iae.getMessage());
-		}
-	}
+    @Override
+    public void setValue(java.lang.String s) {
+        try {
+            value = {{class_name}}_ENUM.valueOf(s.trim());
+            initialized = true;
+        } catch (IllegalArgumentException iae) {
+            LOG.error("IllegalArgumentException: " + iae.getMessage());
+        }
+    }
 
-	@Override
-	public Object getValue() {
-		return value.toString();
-	}
+    @Override
+    public Object getValue() {
+        return value.toString();
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, BaseClass value) {
-		throw new IllegalArgumentException("ENUM cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, BaseClass value) {
+        throw new IllegalArgumentException("ENUM cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, java.lang.String value) {
-		throw new IllegalArgumentException("ENUM cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, java.lang.String value) {
+        throw new IllegalArgumentException("ENUM cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public java.lang.String toString(boolean topClass) {
-		return "Enum (" + value.toString() + ")";
-	}
+    @Override
+    public java.lang.String toString(boolean topClass) {
+        return "Enum (" + value.toString() + ")";
+    }
 
-	private final java.lang.String debugName = "{{class_name}}";
+    private final java.lang.String debugName = "{{class_name}}";
 
-	@Override
-	public java.lang.String debugString() {
-		return debugName;
-	}
+    @Override
+    public java.lang.String debugString() {
+        return debugName;
+    }
 }

--- a/cimgen/languages/java/templates/java_float.mustache
+++ b/cimgen/languages/java/templates/java_float.mustache
@@ -11,73 +11,73 @@ package cim4j;
 {{/class_comment}}
 public class {{class_name}} extends BaseClass {
 
-	private static final Logging LOG = Logging.getLogger({{class_name}}.class);
+    private static final Logging LOG = Logging.getLogger({{class_name}}.class);
 
-	private double value = 0.0;
+    private double value = 0.0;
 
-	private boolean initialized = false;
+    private boolean initialized = false;
 
-	public {{class_name}}() {
-	}
+    public {{class_name}}() {
+    }
 
-	public {{class_name}}(double v) {
-		value = v;
-		initialized = true;
-	}
+    public {{class_name}}(double v) {
+        value = v;
+        initialized = true;
+    }
 
-	public {{class_name}}(java.lang.String s) {
-		setValue(s);
-	}
+    public {{class_name}}(java.lang.String s) {
+        setValue(s);
+    }
 
-	@Override
-	public BaseClass construct() {
-		return new {{class_name}}();
-	}
+    @Override
+    public BaseClass construct() {
+        return new {{class_name}}();
+    }
 
-	@Override
-	public boolean isPrimitive() {
-		return true;
-	}
+    @Override
+    public boolean isPrimitive() {
+        return true;
+    }
 
-	@Override
-	public boolean isInitialized() {
-		return initialized;
-	}
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
-	@Override
-	public void setValue(java.lang.String s) {
-		try {
-			value = java.lang.Float.valueOf(s.trim()).floatValue();
-			initialized = true;
-		} catch (NumberFormatException nfe) {
-			LOG.error("NumberFormatException: " + nfe.getMessage());
-		}
-	}
+    @Override
+    public void setValue(java.lang.String s) {
+        try {
+            value = java.lang.Float.valueOf(s.trim()).floatValue();
+            initialized = true;
+        } catch (NumberFormatException nfe) {
+            LOG.error("NumberFormatException: " + nfe.getMessage());
+        }
+    }
 
-	@Override
-	public Object getValue() {
-		return Double.valueOf(value);
-	}
+    @Override
+    public Object getValue() {
+        return Double.valueOf(value);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, BaseClass value) {
-		throw new IllegalArgumentException("Float class cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, BaseClass value) {
+        throw new IllegalArgumentException("Float class cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, java.lang.String value) {
-		throw new IllegalArgumentException("Float class cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, java.lang.String value) {
+        throw new IllegalArgumentException("Float class cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public java.lang.String toString(boolean topClass) {
-		return "Float: (" + Double.toString(value) + ")";
-	}
+    @Override
+    public java.lang.String toString(boolean topClass) {
+        return "Float: (" + Double.toString(value) + ")";
+    }
 
-	private final java.lang.String debugName = "{{class_name}}";
+    private final java.lang.String debugName = "{{class_name}}";
 
-	@Override
-	public java.lang.String debugString() {
-		return debugName;
-	}
+    @Override
+    public java.lang.String debugString() {
+        return debugName;
+    }
 }

--- a/cimgen/languages/java/templates/java_string.mustache
+++ b/cimgen/languages/java/templates/java_string.mustache
@@ -11,62 +11,62 @@ package cim4j;
 {{/class_comment}}
 public class {{class_name}} extends BaseClass {
 
-	private java.lang.String value = "";
+    private java.lang.String value = "";
 
-	private boolean initialized = false;
+    private boolean initialized = false;
 
-	public {{class_name}}() {
-	}
+    public {{class_name}}() {
+    }
 
-	public {{class_name}}(java.lang.String s) {
-		setValue(s);
-	}
+    public {{class_name}}(java.lang.String s) {
+        setValue(s);
+    }
 
-	@Override
-	public BaseClass construct() {
-		return new {{class_name}}();
-	}
+    @Override
+    public BaseClass construct() {
+        return new {{class_name}}();
+    }
 
-	@Override
-	public boolean isPrimitive() {
-		return true;
-	}
+    @Override
+    public boolean isPrimitive() {
+        return true;
+    }
 
-	@Override
-	public boolean isInitialized() {
-		return initialized;
-	}
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
-	@Override
-	public void setValue(java.lang.String s) {
-		value = s;
-		initialized = true;
-	}
+    @Override
+    public void setValue(java.lang.String s) {
+        value = s;
+        initialized = true;
+    }
 
-	@Override
-	public Object getValue() {
-		return value;
-	}
+    @Override
+    public Object getValue() {
+        return value;
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, BaseClass value) {
-		throw new IllegalArgumentException("String class cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, BaseClass value) {
+        throw new IllegalArgumentException("String class cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public void setAttribute(java.lang.String attrName, java.lang.String value) {
-		throw new IllegalArgumentException("String class cannot set attribute: " + attrName);
-	}
+    @Override
+    public void setAttribute(java.lang.String attrName, java.lang.String value) {
+        throw new IllegalArgumentException("String class cannot set attribute: " + attrName);
+    }
 
-	@Override
-	public java.lang.String toString(boolean topClass) {
-		return value;
-	}
+    @Override
+    public java.lang.String toString(boolean topClass) {
+        return value;
+    }
 
-	private final java.lang.String debugName = "{{class_name}}";
+    private final java.lang.String debugName = "{{class_name}}";
 
-	@Override
-	public java.lang.String debugString() {
-		return debugName;
-	}
+    @Override
+    public java.lang.String debugString() {
+        return debugName;
+    }
 }

--- a/cimgen/languages/java/utils/RdfParser.java
+++ b/cimgen/languages/java/utils/RdfParser.java
@@ -18,122 +18,122 @@ import cim4j.CimConstants;
  */
 public final class RdfParser {
 
-	private static final String RDF = CimConstants.NAMESPACES_MAP.get("rdf");
+    private static final String RDF = CimConstants.NAMESPACES_MAP.get("rdf");
 
-	/**
-	 * Parse the CIM data from a stream.
-	 *
-	 * The stream is expected to contain RDF/XML data which represent CIM data. For
-	 * each element with attributes the consumer createCimObjectFunction is called.
-	 *
-	 * @param stream          Input stream to parse
-	 * @param createCimObject Consumer function
-	 */
-	public static void parse(InputStream stream, Consumer<Element> createCimObjectFunction) {
-		try {
-			var factory = XMLInputFactory.newInstance();
-			var parser = factory.createXMLStreamReader(stream);
+    /**
+     * Parse the CIM data from a stream.
+     *
+     * The stream is expected to contain RDF/XML data which represent CIM data. For
+     * each element with attributes the consumer createCimObjectFunction is called.
+     *
+     * @param stream          Input stream to parse
+     * @param createCimObject Consumer function
+     */
+    public static void parse(InputStream stream, Consumer<Element> createCimObjectFunction) {
+        try {
+            var factory = XMLInputFactory.newInstance();
+            var parser = factory.createXMLStreamReader(stream);
 
-			// Check if root element has RDF namespace
-			parser.nextTag();
-			if (!parser.getName().getNamespaceURI().equals(RDF)) {
-				throw new RuntimeException("No RDF data");
-			}
+            // Check if root element has RDF namespace
+            parser.nextTag();
+            if (!parser.getName().getNamespaceURI().equals(RDF)) {
+                throw new RuntimeException("No RDF data");
+            }
 
-			// Parse over all elements
-			while (parser.hasNext()) {
-				int eventType = parser.next();
-				if (eventType == XMLStreamConstants.START_ELEMENT) {
-					var element = new Element();
-					element.name = parser.getName();
-					element.id = getIdOrAbout(parser);
+            // Parse over all elements
+            while (parser.hasNext()) {
+                int eventType = parser.next();
+                if (eventType == XMLStreamConstants.START_ELEMENT) {
+                    var element = new Element();
+                    element.name = parser.getName();
+                    element.id = getIdOrAbout(parser);
 
-					// Parse over the attributes of the element
-					element.attributes = parseAttributes(parser, element.name);
+                    // Parse over the attributes of the element
+                    element.attributes = parseAttributes(parser, element.name);
 
-					// Call the consumer function for each element
-					createCimObjectFunction.accept(element);
-				}
-			}
-		} catch (Exception ex) {
-			throw new RuntimeException("Error while parsing RDF/XML data", ex);
-		}
-	}
+                    // Call the consumer function for each element
+                    createCimObjectFunction.accept(element);
+                }
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException("Error while parsing RDF/XML data", ex);
+        }
+    }
 
-	private static List<Attribute> parseAttributes(XMLStreamReader parser, QName outerName) throws XMLStreamException {
-		var attributeList = new LinkedList<Attribute>();
-		var attribute = new Attribute();
+    private static List<Attribute> parseAttributes(XMLStreamReader parser, QName outerName) throws XMLStreamException {
+        var attributeList = new LinkedList<Attribute>();
+        var attribute = new Attribute();
 
-		// Parse over all attributes
-		while (parser.hasNext()) {
-			int eventType = parser.next();
+        // Parse over all attributes
+        while (parser.hasNext()) {
+            int eventType = parser.next();
 
-			if (eventType == XMLStreamConstants.START_ELEMENT) {
-				// Start of an attribute
-				attribute.name = parser.getName();
-				attribute.resource = getResource(parser);
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                // Start of an attribute
+                attribute.name = parser.getName();
+                attribute.resource = getResource(parser);
 
-			} else if (eventType == XMLStreamConstants.CHARACTERS && !parser.isWhiteSpace()) {
-				// Value of the attribute
-				attribute.value = parser.getText();
+            } else if (eventType == XMLStreamConstants.CHARACTERS && !parser.isWhiteSpace()) {
+                // Value of the attribute
+                attribute.value = parser.getText();
 
-			} else if (eventType == XMLStreamConstants.END_ELEMENT) {
-				if (parser.getName().equals(attribute.name)) {
-					// End of the attribute
-					attributeList.add(attribute);
-					attribute = new Attribute();
-				} else if (parser.getName().equals(outerName)) {
-					// End of the element
-					break;
-				}
-			}
-		}
-		return attributeList;
-	}
+            } else if (eventType == XMLStreamConstants.END_ELEMENT) {
+                if (parser.getName().equals(attribute.name)) {
+                    // End of the attribute
+                    attributeList.add(attribute);
+                    attribute = new Attribute();
+                } else if (parser.getName().equals(outerName)) {
+                    // End of the element
+                    break;
+                }
+            }
+        }
+        return attributeList;
+    }
 
-	private static String getIdOrAbout(XMLStreamReader parser) {
-		for (int idx = 0; idx < parser.getAttributeCount(); ++idx) {
-			var name = parser.getAttributeName(idx);
-			if (name.getNamespaceURI().equals(RDF)) {
-				var value = parser.getAttributeValue(idx);
-				var local = name.getLocalPart();
-				if (local.equals("ID")) {
-					return value;
-				}
-				if (local.equals("about")) {
-					if (value.startsWith("#")) {
-						value = value.substring(1);
-					}
-					return value;
-				}
-			}
-		}
-		return null;
-	}
+    private static String getIdOrAbout(XMLStreamReader parser) {
+        for (int idx = 0; idx < parser.getAttributeCount(); ++idx) {
+            var name = parser.getAttributeName(idx);
+            if (name.getNamespaceURI().equals(RDF)) {
+                var value = parser.getAttributeValue(idx);
+                var local = name.getLocalPart();
+                if (local.equals("ID")) {
+                    return value;
+                }
+                if (local.equals("about")) {
+                    if (value.startsWith("#")) {
+                        value = value.substring(1);
+                    }
+                    return value;
+                }
+            }
+        }
+        return null;
+    }
 
-	private static String getResource(XMLStreamReader parser) {
-		for (int idx = 0; idx < parser.getAttributeCount(); ++idx) {
-			var name = parser.getAttributeName(idx);
-			if (name.getNamespaceURI().equals(RDF) && name.getLocalPart().equals("resource")) {
-				var value = parser.getAttributeValue(idx);
-				if (value.startsWith("#")) {
-					value = value.substring(1);
-				}
-				return value;
-			}
-		}
-		return null;
-	}
+    private static String getResource(XMLStreamReader parser) {
+        for (int idx = 0; idx < parser.getAttributeCount(); ++idx) {
+            var name = parser.getAttributeName(idx);
+            if (name.getNamespaceURI().equals(RDF) && name.getLocalPart().equals("resource")) {
+                var value = parser.getAttributeValue(idx);
+                if (value.startsWith("#")) {
+                    value = value.substring(1);
+                }
+                return value;
+            }
+        }
+        return null;
+    }
 
-	public static class Element {
-		public QName name;
-		public String id;
-		public List<Attribute> attributes;
-	}
+    public static class Element {
+        public QName name;
+        public String id;
+        public List<Attribute> attributes;
+    }
 
-	public static class Attribute {
-		public QName name;
-		public String resource;
-		public String value;
-	}
+    public static class Attribute {
+        public QName name;
+        public String resource;
+        public String value;
+    }
 }

--- a/cimgen/languages/java/utils/RdfParser.java
+++ b/cimgen/languages/java/utils/RdfParser.java
@@ -1,9 +1,9 @@
 package cim4j.utils;
 
 import java.io.InputStream;
-import java.util.function.Consumer;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.LinkedList;
+import java.util.function.Consumer;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
@@ -62,7 +62,7 @@ public final class RdfParser {
     }
 
     private static List<Attribute> parseAttributes(XMLStreamReader parser, QName outerName) throws XMLStreamException {
-        var attributeList = new LinkedList<Attribute>();
+        var attributeList = new ArrayList<Attribute>();
         var attribute = new Attribute();
 
         // Parse over all attributes

--- a/cimgen/languages/java/utils/RdfParser.java
+++ b/cimgen/languages/java/utils/RdfParser.java
@@ -19,6 +19,7 @@ import cim4j.CimConstants;
 public final class RdfParser {
 
     private static final String RDF = CimConstants.NAMESPACES_MAP.get("rdf");
+    private static final String MD = CimConstants.NAMESPACES_MAP.get("md"); // ModelDescription
 
     /**
      * Parse the CIM data from a stream.
@@ -43,7 +44,7 @@ public final class RdfParser {
             // Parse over all elements
             while (parser.hasNext()) {
                 int eventType = parser.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (eventType == XMLStreamConstants.START_ELEMENT && !parser.getName().getNamespaceURI().equals(MD)) {
                     var element = new Element();
                     element.name = parser.getName();
                     element.id = getIdOrAbout(parser);

--- a/cimgen/languages/java/utils/RdfParser.java
+++ b/cimgen/languages/java/utils/RdfParser.java
@@ -1,0 +1,139 @@
+package cim4j.utils;
+
+import java.io.InputStream;
+import java.util.function.Consumer;
+import java.util.List;
+import java.util.LinkedList;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import cim4j.CimConstants;
+
+/**
+ * Read RDF files into a map of rdfid to CIM object.
+ */
+public final class RdfParser {
+
+	private static final String RDF = CimConstants.NAMESPACES_MAP.get("rdf");
+
+	/**
+	 * Parse the CIM data from a stream.
+	 *
+	 * The stream is expected to contain RDF/XML data which represent CIM data. For
+	 * each element with attributes the consumer createCimObjectFunction is called.
+	 *
+	 * @param stream          Input stream to parse
+	 * @param createCimObject Consumer function
+	 */
+	public static void parse(InputStream stream, Consumer<Element> createCimObjectFunction) {
+		try {
+			var factory = XMLInputFactory.newInstance();
+			var parser = factory.createXMLStreamReader(stream);
+
+			// Check if root element has RDF namespace
+			parser.nextTag();
+			if (!parser.getName().getNamespaceURI().equals(RDF)) {
+				throw new RuntimeException("No RDF data");
+			}
+
+			// Parse over all elements
+			while (parser.hasNext()) {
+				int eventType = parser.next();
+				if (eventType == XMLStreamConstants.START_ELEMENT) {
+					var element = new Element();
+					element.name = parser.getName();
+					element.id = getIdOrAbout(parser);
+
+					// Parse over the attributes of the element
+					element.attributes = parseAttributes(parser, element.name);
+
+					// Call the consumer function for each element
+					createCimObjectFunction.accept(element);
+				}
+			}
+		} catch (Exception ex) {
+			throw new RuntimeException("Error while parsing RDF/XML data", ex);
+		}
+	}
+
+	private static List<Attribute> parseAttributes(XMLStreamReader parser, QName outerName) throws XMLStreamException {
+		var attributeList = new LinkedList<Attribute>();
+		var attribute = new Attribute();
+
+		// Parse over all attributes
+		while (parser.hasNext()) {
+			int eventType = parser.next();
+
+			if (eventType == XMLStreamConstants.START_ELEMENT) {
+				// Start of an attribute
+				attribute.name = parser.getName();
+				attribute.resource = getResource(parser);
+
+			} else if (eventType == XMLStreamConstants.CHARACTERS && !parser.isWhiteSpace()) {
+				// Value of the attribute
+				attribute.value = parser.getText();
+
+			} else if (eventType == XMLStreamConstants.END_ELEMENT) {
+				if (parser.getName().equals(attribute.name)) {
+					// End of the attribute
+					attributeList.add(attribute);
+					attribute = new Attribute();
+				} else if (parser.getName().equals(outerName)) {
+					// End of the element
+					break;
+				}
+			}
+		}
+		return attributeList;
+	}
+
+	private static String getIdOrAbout(XMLStreamReader parser) {
+		for (int idx = 0; idx < parser.getAttributeCount(); ++idx) {
+			var name = parser.getAttributeName(idx);
+			if (name.getNamespaceURI().equals(RDF)) {
+				var value = parser.getAttributeValue(idx);
+				var local = name.getLocalPart();
+				if (local.equals("ID")) {
+					return value;
+				}
+				if (local.equals("about")) {
+					if (value.startsWith("#")) {
+						value = value.substring(1);
+					}
+					return value;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static String getResource(XMLStreamReader parser) {
+		for (int idx = 0; idx < parser.getAttributeCount(); ++idx) {
+			var name = parser.getAttributeName(idx);
+			if (name.getNamespaceURI().equals(RDF) && name.getLocalPart().equals("resource")) {
+				var value = parser.getAttributeValue(idx);
+				if (value.startsWith("#")) {
+					value = value.substring(1);
+				}
+				return value;
+			}
+		}
+		return null;
+	}
+
+	public static class Element {
+		public QName name;
+		public String id;
+		public List<Attribute> attributes;
+	}
+
+	public static class Attribute {
+		public QName name;
+		public String resource;
+		public String value;
+	}
+}

--- a/cimgen/languages/java/utils/RdfReader.java
+++ b/cimgen/languages/java/utils/RdfReader.java
@@ -16,114 +16,114 @@ import cim4j.Logging;
  */
 public final class RdfReader {
 
-	private static final Logging LOG = Logging.getLogger(RdfReader.class);
+    private static final Logging LOG = Logging.getLogger(RdfReader.class);
 
-	private static Map<String, BaseClass> model = new LinkedHashMap<>();
-	private static Map<String, List<SetAttribute>> setAttributeMap = new LinkedHashMap<>();
+    private static Map<String, BaseClass> model = new LinkedHashMap<>();
+    private static Map<String, List<SetAttribute>> setAttributeMap = new LinkedHashMap<>();
 
-	/**
-	 * Read the CIM data from a RDF file.
-	 *
-	 * @param path Path of file to read
-	 * @return CIM data as map of rdfid to CIM object
-	 */
-	public static Map<String, BaseClass> read(String path) {
-		try (var stream = new FileInputStream(path)) {
-			return read(stream);
-		} catch (Exception ex) {
-			String txt = "Error while reading rdf file: " + path;
-			LOG.error(txt, ex);
-			throw new RuntimeException(txt, ex);
-		}
-	}
+    /**
+     * Read the CIM data from a RDF file.
+     *
+     * @param path Path of file to read
+     * @return CIM data as map of rdfid to CIM object
+     */
+    public static Map<String, BaseClass> read(String path) {
+        try (var stream = new FileInputStream(path)) {
+            return read(stream);
+        } catch (Exception ex) {
+            String txt = "Error while reading rdf file: " + path;
+            LOG.error(txt, ex);
+            throw new RuntimeException(txt, ex);
+        }
+    }
 
-	/**
-	 * Read the CIM data from a stream.
-	 *
-	 * @param stream Input stream to read
-	 * @return CIM data as map of rdfid to CIM object
-	 */
-	public static Map<String, BaseClass> read(InputStream stream) {
-		model.clear();
-		setAttributeMap.clear();
-		RdfParser.parse(stream, RdfReader::createCimObject);
-		setRemainingAttributes();
-		return model;
-	}
+    /**
+     * Read the CIM data from a stream.
+     *
+     * @param stream Input stream to read
+     * @return CIM data as map of rdfid to CIM object
+     */
+    public static Map<String, BaseClass> read(InputStream stream) {
+        model.clear();
+        setAttributeMap.clear();
+        RdfParser.parse(stream, RdfReader::createCimObject);
+        setRemainingAttributes();
+        return model;
+    }
 
-	private static void createCimObject(RdfParser.Element element) {
-		var className = element.name.getLocalPart();
-		if (element.id != null) {
-			if (CIMClassMap.isCIMClass(className)) {
-				BaseClass object = model.get(element.id);
-				if (object == null) {
-					object = createNewObject(className, element.id);
-					model.put(element.id, object);
-				}
+    private static void createCimObject(RdfParser.Element element) {
+        var className = element.name.getLocalPart();
+        if (element.id != null) {
+            if (CIMClassMap.isCIMClass(className)) {
+                BaseClass object = model.get(element.id);
+                if (object == null) {
+                    object = createNewObject(className, element.id);
+                    model.put(element.id, object);
+                }
 
-				// Set attributes of new object
-				for (RdfParser.Attribute attribute : element.attributes) {
-					setAttribute(object, attribute);
-				}
-			} else {
-				LOG.warn(String.format("Unknown CIM class: %s (rdf:ID: %s)", className, element.id));
-			}
-		} else {
-			LOG.warn(String.format("Possible CIM class: %s (rdf:ID missing)", className));
-		}
-	}
+                // Set attributes of new object
+                for (RdfParser.Attribute attribute : element.attributes) {
+                    setAttribute(object, attribute);
+                }
+            } else {
+                LOG.warn(String.format("Unknown CIM class: %s (rdf:ID: %s)", className, element.id));
+            }
+        } else {
+            LOG.warn(String.format("Possible CIM class: %s (rdf:ID missing)", className));
+        }
+    }
 
-	private static BaseClass createNewObject(String className, String rdfid) {
-		final BaseClass template = CIMClassMap.classMap.get(className);
-		if (template != null) {
-			BaseClass object = template.construct();
-			object.setRdfid(rdfid);
-			LOG.debug(String.format("Created object of type: %s with rdf:ID: %s", className, rdfid));
-			return object;
-		}
-		return null;
-	}
+    private static BaseClass createNewObject(String className, String rdfid) {
+        final BaseClass template = CIMClassMap.classMap.get(className);
+        if (template != null) {
+            BaseClass object = template.construct();
+            object.setRdfid(rdfid);
+            LOG.debug(String.format("Created object of type: %s with rdf:ID: %s", className, rdfid));
+            return object;
+        }
+        return null;
+    }
 
-	private static void setAttribute(BaseClass object, RdfParser.Attribute attribute) {
-		var attributeName = attribute.name.getLocalPart();
-		if (attributeName.contains(".")) {
-			attributeName = attributeName.substring(attributeName.lastIndexOf('.') + 1);
-		}
-		if (attribute.resource != null) {
-			if (model.containsKey(attribute.resource)) {
-				BaseClass attributeObject = model.get(attribute.resource);
-				object.setAttribute(attributeName, attributeObject);
-			} else {
-				// Set attribute later in setRemainingAttributes
-				var setAttribute = new SetAttribute(attributeName, object);
-				setAttributeMap.computeIfAbsent(attribute.resource, k -> new LinkedList<>()).add(setAttribute);
-			}
-		} else {
-			object.setAttribute(attributeName, attribute.value);
-		}
-	}
+    private static void setAttribute(BaseClass object, RdfParser.Attribute attribute) {
+        var attributeName = attribute.name.getLocalPart();
+        if (attributeName.contains(".")) {
+            attributeName = attributeName.substring(attributeName.lastIndexOf('.') + 1);
+        }
+        if (attribute.resource != null) {
+            if (model.containsKey(attribute.resource)) {
+                BaseClass attributeObject = model.get(attribute.resource);
+                object.setAttribute(attributeName, attributeObject);
+            } else {
+                // Set attribute later in setRemainingAttributes
+                var setAttribute = new SetAttribute(attributeName, object);
+                setAttributeMap.computeIfAbsent(attribute.resource, k -> new LinkedList<>()).add(setAttribute);
+            }
+        } else {
+            object.setAttribute(attributeName, attribute.value);
+        }
+    }
 
-	private static void setRemainingAttributes() {
-		for (var resource : setAttributeMap.keySet()) {
-			var setAttributeList = setAttributeMap.get(resource);
-			BaseClass attributeObject = model.get(resource);
-			if (attributeObject == null) {
-				attributeObject = createNewObject("IdentifiedObject", resource);
-				model.put(resource, attributeObject);
-			}
-			for (var setAttribute : setAttributeList) {
-				setAttribute.object.setAttribute(setAttribute.name, attributeObject);
-			}
-		}
-	}
+    private static void setRemainingAttributes() {
+        for (var resource : setAttributeMap.keySet()) {
+            var setAttributeList = setAttributeMap.get(resource);
+            BaseClass attributeObject = model.get(resource);
+            if (attributeObject == null) {
+                attributeObject = createNewObject("IdentifiedObject", resource);
+                model.put(resource, attributeObject);
+            }
+            for (var setAttribute : setAttributeList) {
+                setAttribute.object.setAttribute(setAttribute.name, attributeObject);
+            }
+        }
+    }
 
-	public static class SetAttribute {
-		public SetAttribute(String n, BaseClass o) {
-			name = n;
-			object = o;
-		}
+    public static class SetAttribute {
+        public SetAttribute(String n, BaseClass o) {
+            name = n;
+            object = o;
+        }
 
-		public String name;
-		public BaseClass object;
-	}
+        public String name;
+        public BaseClass object;
+    }
 }

--- a/cimgen/languages/java/utils/RdfReader.java
+++ b/cimgen/languages/java/utils/RdfReader.java
@@ -8,7 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import cim4j.BaseClass;
-import cim4j.CIMClassMap;
+import cim4j.CimClassMap;
 import cim4j.Logging;
 
 /**
@@ -54,7 +54,7 @@ public final class RdfReader {
     private static void createCimObject(RdfParser.Element element) {
         var className = element.name.getLocalPart();
         if (element.id != null) {
-            if (CIMClassMap.isCIMClass(className)) {
+            if (CimClassMap.isCimClass(className)) {
                 BaseClass object = model.get(element.id);
                 if (object == null) {
                     object = createNewObject(className, element.id);
@@ -74,14 +74,10 @@ public final class RdfReader {
     }
 
     private static BaseClass createNewObject(String className, String rdfid) {
-        final BaseClass template = CIMClassMap.classMap.get(className);
-        if (template != null) {
-            BaseClass object = template.construct();
-            object.setRdfid(rdfid);
-            LOG.debug(String.format("Created object of type: %s with rdf:ID: %s", className, rdfid));
-            return object;
-        }
-        return null;
+        BaseClass object = CimClassMap.createCimObject(className);
+        object.setRdfid(rdfid);
+        LOG.debug(String.format("Created object of type: %s with rdf:ID: %s", className, rdfid));
+        return object;
     }
 
     private static void setAttribute(BaseClass object, RdfParser.Attribute attribute) {

--- a/cimgen/languages/java/utils/RdfReader.java
+++ b/cimgen/languages/java/utils/RdfReader.java
@@ -1,52 +1,35 @@
 package cim4j.utils;
 
-import java.util.Collections;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.LinkedList;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Stack;
-
-import javax.xml.parsers.SAXParserFactory;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.helpers.DefaultHandler;
 
 import cim4j.BaseClass;
 import cim4j.CIMClassMap;
 import cim4j.Logging;
 
 /**
- * Read rdf files into a map of rdfid to cim object.
+ * Read RDF files into a map of rdfid to CIM object.
  */
-public class RdfReader extends DefaultHandler {
+public final class RdfReader {
 
 	private static final Logging LOG = Logging.getLogger(RdfReader.class);
 
-	private LinkedHashMap<String, BaseClass> model;
-	private Stack<String> subjectStack;
-	private Stack<BaseClass> objectStack;
+	private static Map<String, BaseClass> model = new LinkedHashMap<>();
+	private static Map<String, List<SetAttribute>> setAttributeMap = new LinkedHashMap<>();
 
 	/**
-	 * Read the cim data from a rdf file.
+	 * Read the CIM data from a RDF file.
 	 *
-	 * @param path path of file to read
+	 * @param path Path of file to read
+	 * @return CIM data as map of rdfid to CIM object
 	 */
 	public static Map<String, BaseClass> read(String path) {
-		try {
-			var parserFactory = SAXParserFactory.newInstance();
-			parserFactory.setNamespaceAware(true);
-
-			var parser = parserFactory.newSAXParser();
-			var reader = parser.getXMLReader();
-
-			var handler = new RdfReader();
-			reader.setContentHandler(handler);
-			reader.setErrorHandler(handler);
-
-			reader.parse(path);
-
-			return handler.getModel();
+		try (var stream = new FileInputStream(path)) {
+			return read(stream);
 		} catch (Exception ex) {
 			String txt = "Error while reading rdf file: " + path;
 			LOG.error(txt, ex);
@@ -54,166 +37,93 @@ public class RdfReader extends DefaultHandler {
 		}
 	}
 
-	public Map<String, BaseClass> getModel() {
-		return Collections.unmodifiableMap(model);
+	/**
+	 * Read the CIM data from a stream.
+	 *
+	 * @param stream Input stream to read
+	 * @return CIM data as map of rdfid to CIM object
+	 */
+	public static Map<String, BaseClass> read(InputStream stream) {
+		model.clear();
+		setAttributeMap.clear();
+		RdfParser.parse(stream, RdfReader::createCimObject);
+		setRemainingAttributes();
+		return model;
 	}
 
-	@Override
-	public void startDocument() {
-		model = new LinkedHashMap<>();
-		subjectStack = new Stack<>();
-		objectStack = new Stack<>();
-	}
+	private static void createCimObject(RdfParser.Element element) {
+		var className = element.name.getLocalPart();
+		if (element.id != null) {
+			if (CIMClassMap.isCIMClass(className)) {
+				BaseClass object = model.get(element.id);
+				if (object == null) {
+					object = createNewObject(className, element.id);
+					model.put(element.id, object);
+				}
 
-	@Override
-	public void characters(char[] ch, int start, int length) {
-		String content = String.valueOf(ch, start, length);
-		if (!content.isBlank() && !subjectStack.empty()) {
-			String subject = subjectStack.peek();
-			if (!objectStack.empty()) {
-				BaseClass object = objectStack.peek();
-				object.setAttribute(subject, content);
-			} else {
-				LOG.error(String.format("Cannot set attribute with name %s because object stack is empty", subject));
-			}
-		}
-	}
-
-	private BaseClass createOrLinkObject(String className, String rdfid) {
-		if (rdfid.startsWith("#")) {
-			rdfid = rdfid.substring(1);
-		}
-		final BaseClass template = CIMClassMap.classMap.get(className);
-		if (template != null) {
-			BaseClass object;
-			if (model.containsKey(rdfid)) {
-				object = model.get(rdfid);
-				var oldType = object.getClass();
-				var newType = template.getClass();
-				if (!oldType.equals(newType) && oldType.isAssignableFrom(newType)) {
-					var oldObject = object;
-					LOG.debug(String.format("Retyping object with rdf:ID: %s from type: %s to type: %s", rdfid,
-							oldObject.debugString(), className));
-					// Create new object with new type
-					object = template.construct();
-					object.setRdfid(rdfid);
-					// Copy attributes from old object to the new object
-					for (String attrName : oldObject.getAttributeNames()) {
-						var attrObj = oldObject.getAttribute(attrName);
-						if (attrObj != null) {
-							object.setAttribute(attrName, attrObj);
-						}
-					}
-					// Replace old object with new object in attributes of all objects in the model
-					for (var cimObj : model.values()) {
-						for (String attrName : cimObj.getAttributeNames()) {
-							if (cimObj.getAttribute(attrName) == oldObject) {
-								cimObj.setAttribute(attrName, object);
-							}
-						}
-					}
-					// Replace old object with new object in model
-					model.put(rdfid, object);
-				} else {
-					LOG.debug(String.format("Found %s with rdf:ID: %s in map", object.debugString(), rdfid));
+				// Set attributes of new object
+				for (RdfParser.Attribute attribute : element.attributes) {
+					setAttribute(object, attribute);
 				}
 			} else {
-				LOG.debug(String.format("Creating object of type: %s with rdf:ID: %s", className, rdfid));
-				object = template.construct();
-				object.setRdfid(rdfid);
-				model.put(rdfid, object);
+				LOG.warn(String.format("Unknown CIM class: %s (rdf:ID: %s)", className, element.id));
 			}
+		} else {
+			LOG.warn(String.format("Possible CIM class: %s (rdf:ID missing)", className));
+		}
+	}
+
+	private static BaseClass createNewObject(String className, String rdfid) {
+		final BaseClass template = CIMClassMap.classMap.get(className);
+		if (template != null) {
+			BaseClass object = template.construct();
+			object.setRdfid(rdfid);
+			LOG.debug(String.format("Created object of type: %s with rdf:ID: %s", className, rdfid));
 			return object;
 		}
-
-		LOG.debug(String.format("Could not find %s in map", className));
 		return null;
 	}
 
-	@Override
-	public void startElement(String namespaceUri, String localName, String qName, Attributes attributes) {
-		if (qName.startsWith("rdf") || qName.startsWith("md")) {
-			return;
+	private static void setAttribute(BaseClass object, RdfParser.Attribute attribute) {
+		var attributeName = attribute.name.getLocalPart();
+		if (attributeName.contains(".")) {
+			attributeName = attributeName.substring(attributeName.lastIndexOf('.') + 1);
 		}
-
-		int lastDot = localName.lastIndexOf('.');
-		String attributeName;
-		if (lastDot > 0) {
-			attributeName = localName.substring(lastDot + 1);
+		if (attribute.resource != null) {
+			if (model.containsKey(attribute.resource)) {
+				BaseClass attributeObject = model.get(attribute.resource);
+				object.setAttribute(attributeName, attributeObject);
+			} else {
+				// Set attribute later in setRemainingAttributes
+				var setAttribute = new SetAttribute(attributeName, object);
+				setAttributeMap.computeIfAbsent(attribute.resource, k -> new LinkedList<>()).add(setAttribute);
+			}
 		} else {
-			attributeName = localName;
+			object.setAttribute(attributeName, attribute.value);
 		}
+	}
 
-		subjectStack.push(attributeName);
-
-		for (int idx = 0; idx < attributes.getLength(); ++idx) {
-			qName = attributes.getQName(idx);
-			if (qName.equals("rdf:ID") || qName.equals("rdf:about")) {
-				String rdfid = attributes.getValue(idx);
-
-				// If we have a class, make a new object and record it in the map
-				if (CIMClassMap.isCIMClass(localName)) {
-					BaseClass object = createOrLinkObject(localName, rdfid);
-					objectStack.push(object);
-				} else {
-					LOG.debug(String.format("Possible class element: %s", localName));
-				}
+	private static void setRemainingAttributes() {
+		for (var resource : setAttributeMap.keySet()) {
+			var setAttributeList = setAttributeMap.get(resource);
+			BaseClass attributeObject = model.get(resource);
+			if (attributeObject == null) {
+				attributeObject = createNewObject("IdentifiedObject", resource);
+				model.put(resource, attributeObject);
 			}
-			if (qName.equals("rdf:resource")) {
-				String rdfid = attributes.getValue(idx);
-
-				if (!objectStack.isEmpty()) {
-					BaseClass object = objectStack.peek();
-					if (object != null) {
-						BaseClass attributeObject = createOrLinkObject("IdentifiedObject", rdfid);
-						object.setAttribute(attributeName, attributeObject);
-					}
-				}
+			for (var setAttribute : setAttributeList) {
+				setAttribute.object.setAttribute(setAttribute.name, attributeObject);
 			}
 		}
 	}
 
-	@Override
-	public void endElement(String namespaceUri, String localName, String qName) {
-		if (!subjectStack.empty()) {
-			subjectStack.pop();
+	public static class SetAttribute {
+		public SetAttribute(String n, BaseClass o) {
+			name = n;
+			object = o;
 		}
-		if (CIMClassMap.isCIMClass(localName)) {
-			if (!objectStack.empty()) {
-				objectStack.pop();
-			}
-		}
-	}
 
-	@Override
-	public void endDocument() {
-		for (String key : model.keySet()) {
-			var value = model.get(key);
-			String type = value.debugString();
-			LOG.debug(String.format("Model contains a %s with rdf:ID %s and attributes:", type, key));
-			LOG.debug(value.toString(true));
-		}
-	}
-
-	@Override
-	public void warning(SAXParseException ex) {
-		LOG.warn(getParseExceptionInfo(ex), ex);
-	}
-
-	@Override
-	public void error(SAXParseException ex) {
-		LOG.error(getParseExceptionInfo(ex), ex);
-	}
-
-	@Override
-	public void fatalError(SAXParseException ex) throws SAXException {
-		String txt = getParseExceptionInfo(ex);
-		LOG.fatal(txt, ex);
-		throw new SAXException(txt, ex);
-	}
-
-	private String getParseExceptionInfo(SAXParseException ex) {
-		String systemId = ex.getSystemId();
-		return "URI=" + systemId + " Line=" + ex.getLineNumber() + ": " + ex.getMessage();
+		public String name;
+		public BaseClass object;
 	}
 }

--- a/cimgen/languages/java/utils/RdfWriter.java
+++ b/cimgen/languages/java/utils/RdfWriter.java
@@ -24,169 +24,169 @@ import cim4j.Logging;
  */
 public class RdfWriter {
 
-	private static final Logging LOG = Logging.getLogger(RdfWriter.class);
+    private static final Logging LOG = Logging.getLogger(RdfWriter.class);
 
-	private final Map<String, BaseClass> cimData = new LinkedHashMap<>();
+    private final Map<String, BaseClass> cimData = new LinkedHashMap<>();
 
-	/**
-	 * Add cim data as map of rdfid to cim object.
-	 *
-	 * @param newCimData cim data as map of rdfid to cim object
-	 */
-	public void addCimData(Map<String, BaseClass> newCimData) {
-		cimData.putAll(newCimData);
-	}
+    /**
+     * Add cim data as map of rdfid to cim object.
+     *
+     * @param newCimData cim data as map of rdfid to cim object
+     */
+    public void addCimData(Map<String, BaseClass> newCimData) {
+        cimData.putAll(newCimData);
+    }
 
-	/**
-	 * Get cim data.
-	 *
-	 * @return cim data as map of rdfid to cim object
-	 */
-	public Map<String, BaseClass> getCimData() {
-		return Collections.unmodifiableMap(cimData);
-	}
+    /**
+     * Get cim data.
+     *
+     * @return cim data as map of rdfid to cim object
+     */
+    public Map<String, BaseClass> getCimData() {
+        return Collections.unmodifiableMap(cimData);
+    }
 
-	/**
-	 * Clear cim data.
-	 */
-	public void clearCimData() {
-		cimData.clear();
-	}
+    /**
+     * Clear cim data.
+     */
+    public void clearCimData() {
+        cimData.clear();
+    }
 
-	/**
-	 * Write the CIM data to a RDF file.
-	 *
-	 * @param path path of file to write
-	 */
-	public void write(String path) {
-		try (var writer = new BufferedWriter(new FileWriter(path, StandardCharsets.UTF_8))) {
-			write(writer);
-		} catch (Exception ex) {
-			String txt = "Failed to write rdf file";
-			LOG.error(txt, ex);
-			throw new RuntimeException(txt, ex);
-		}
-	}
+    /**
+     * Write the CIM data to a RDF file.
+     *
+     * @param path path of file to write
+     */
+    public void write(String path) {
+        try (var writer = new BufferedWriter(new FileWriter(path, StandardCharsets.UTF_8))) {
+            write(writer);
+        } catch (Exception ex) {
+            String txt = "Failed to write rdf file";
+            LOG.error(txt, ex);
+            throw new RuntimeException(txt, ex);
+        }
+    }
 
-	/**
-	 * Write the CIM data to a stream.
-	 *
-	 * @return cim data as rdf string
-	 */
-	public void write(Writer streamWriter) {
-		final String RDF = CimConstants.NAMESPACES_MAP.get("rdf");
+    /**
+     * Write the CIM data to a stream.
+     *
+     * @return cim data as rdf string
+     */
+    public void write(Writer streamWriter) {
+        final String RDF = CimConstants.NAMESPACES_MAP.get("rdf");
 
-		try {
-			var factory = XMLOutputFactory.newInstance();
-			var writer = factory.createXMLStreamWriter(streamWriter);
+        try {
+            var factory = XMLOutputFactory.newInstance();
+            var writer = factory.createXMLStreamWriter(streamWriter);
 
-			writer.writeStartDocument("utf-8", "1.0");
-			writer.writeCharacters("\n");
+            writer.writeStartDocument("utf-8", "1.0");
+            writer.writeCharacters("\n");
 
-			var usedNamespaces = getUsedNamespaces();
-			var nsList = new ArrayList<>(usedNamespaces.keySet());
-			Collections.sort(nsList);
+            var usedNamespaces = getUsedNamespaces();
+            var nsList = new ArrayList<>(usedNamespaces.keySet());
+            Collections.sort(nsList);
 
-			for (var ns : nsList) {
-				writer.setPrefix(ns, usedNamespaces.get(ns));
-			}
+            for (var ns : nsList) {
+                writer.setPrefix(ns, usedNamespaces.get(ns));
+            }
 
-			writer.writeStartElement(RDF, "RDF");
+            writer.writeStartElement(RDF, "RDF");
 
-			for (var ns : nsList) {
-				writer.writeNamespace(ns, usedNamespaces.get(ns));
-			}
+            for (var ns : nsList) {
+                writer.writeNamespace(ns, usedNamespaces.get(ns));
+            }
 
-			int count = 0;
-			for (String rdfid : cimData.keySet()) {
-				BaseClass cimObj = cimData.get(rdfid);
-				if (!cimObj.getClass().equals(IdentifiedObject.class)) {
-					String cimType = cimObj.debugString();
+            int count = 0;
+            for (String rdfid : cimData.keySet()) {
+                BaseClass cimObj = cimData.get(rdfid);
+                if (!cimObj.getClass().equals(IdentifiedObject.class)) {
+                    String cimType = cimObj.debugString();
 
-					writer.writeCharacters("\n  ");
-					writer.writeStartElement(cimObj.getClassNamespaceUrl(), cimType);
-					writer.writeAttribute(RDF, "ID", rdfid);
+                    writer.writeCharacters("\n  ");
+                    writer.writeStartElement(cimObj.getClassNamespaceUrl(), cimType);
+                    writer.writeAttribute(RDF, "ID", rdfid);
 
-					var attrNames = cimObj.getAttributeNames();
-					for (String attrName : attrNames) {
-						var namespaceUrl = cimObj.getAttributeNamespaceUrl(attrName);
-						String attrFullName = cimObj.getAttributeFullName(attrName);
-						var attrObj = cimObj.getAttribute(attrName);
-						if (attrObj != null) {
-							if (attrObj.isPrimitive()) {
-								var value = attrObj.getValue();
-								if (value != null) {
-									writer.writeCharacters("\n    ");
-									writer.writeStartElement(namespaceUrl, attrFullName);
-									writer.writeCharacters(value.toString());
-									writer.writeEndElement();
-								} else {
-									LOG.error(String.format("No value for attribute %s of %s(%s)", attrFullName,
-											cimType, rdfid));
-								}
-							} else {
-								String attrRdfId = attrObj.getRdfid();
-								if (attrRdfId != null) {
-									if (!attrRdfId.contains("#")) {
-										attrRdfId = "#" + attrRdfId;
-									}
-									writer.writeCharacters("\n    ");
-									writer.writeEmptyElement(namespaceUrl, attrFullName);
-									writer.writeAttribute(RDF, "resource", attrRdfId);
-								} else {
-									LOG.error(
-											String.format("No rdfid for attribute %s of %s(%s)", attrFullName, cimType,
-													rdfid));
-								}
-							}
-						}
-					}
-					writer.writeCharacters("\n  ");
-					writer.writeEndElement();
-					++count;
-				}
-			}
-			writer.writeCharacters("\n");
-			writer.writeEndDocument();
-			writer.writeCharacters("\n");
-			writer.close();
+                    var attrNames = cimObj.getAttributeNames();
+                    for (String attrName : attrNames) {
+                        var namespaceUrl = cimObj.getAttributeNamespaceUrl(attrName);
+                        String attrFullName = cimObj.getAttributeFullName(attrName);
+                        var attrObj = cimObj.getAttribute(attrName);
+                        if (attrObj != null) {
+                            if (attrObj.isPrimitive()) {
+                                var value = attrObj.getValue();
+                                if (value != null) {
+                                    writer.writeCharacters("\n    ");
+                                    writer.writeStartElement(namespaceUrl, attrFullName);
+                                    writer.writeCharacters(value.toString());
+                                    writer.writeEndElement();
+                                } else {
+                                    LOG.error(String.format("No value for attribute %s of %s(%s)", attrFullName,
+                                            cimType, rdfid));
+                                }
+                            } else {
+                                String attrRdfId = attrObj.getRdfid();
+                                if (attrRdfId != null) {
+                                    if (!attrRdfId.contains("#")) {
+                                        attrRdfId = "#" + attrRdfId;
+                                    }
+                                    writer.writeCharacters("\n    ");
+                                    writer.writeEmptyElement(namespaceUrl, attrFullName);
+                                    writer.writeAttribute(RDF, "resource", attrRdfId);
+                                } else {
+                                    LOG.error(
+                                            String.format("No rdfid for attribute %s of %s(%s)", attrFullName, cimType,
+                                                    rdfid));
+                                }
+                            }
+                        }
+                    }
+                    writer.writeCharacters("\n  ");
+                    writer.writeEndElement();
+                    ++count;
+                }
+            }
+            writer.writeCharacters("\n");
+            writer.writeEndDocument();
+            writer.writeCharacters("\n");
+            writer.close();
 
-			LOG.info(String.format("Written %d of %d CIM objects to RDF", count, cimData.size()));
-		} catch (Exception ex) {
-			throw new RuntimeException("Error while writing RDF/XML data", ex);
-		}
-	}
+            LOG.info(String.format("Written %d of %d CIM objects to RDF", count, cimData.size()));
+        } catch (Exception ex) {
+            throw new RuntimeException("Error while writing RDF/XML data", ex);
+        }
+    }
 
-	private Map<java.lang.String, java.lang.String> getUsedNamespaces() {
-		Set<java.lang.String> urls = new HashSet<>();
-		urls.add(CimConstants.NAMESPACES_MAP.get("rdf"));
-		for (String rdfid : cimData.keySet()) {
-			BaseClass cimObj = cimData.get(rdfid);
-			urls.add(cimObj.getClassNamespaceUrl());
-			var attrNames = cimObj.getAttributeNames();
-			for (String attrName : attrNames) {
-				var attrObj = cimObj.getAttribute(attrName);
-				if (attrObj != null) {
-					urls.add(cimObj.getAttributeNamespaceUrl(attrName));
-				}
-			}
-		}
-		Map<java.lang.String, java.lang.String> namespaces = new HashMap<>();
-		for (var url : urls) {
-			var ns = getNamespaceKey(url);
-			if (ns != null) {
-				namespaces.put(ns, url);
-			}
-		}
-		return namespaces;
-	}
+    private Map<java.lang.String, java.lang.String> getUsedNamespaces() {
+        Set<java.lang.String> urls = new HashSet<>();
+        urls.add(CimConstants.NAMESPACES_MAP.get("rdf"));
+        for (String rdfid : cimData.keySet()) {
+            BaseClass cimObj = cimData.get(rdfid);
+            urls.add(cimObj.getClassNamespaceUrl());
+            var attrNames = cimObj.getAttributeNames();
+            for (String attrName : attrNames) {
+                var attrObj = cimObj.getAttribute(attrName);
+                if (attrObj != null) {
+                    urls.add(cimObj.getAttributeNamespaceUrl(attrName));
+                }
+            }
+        }
+        Map<java.lang.String, java.lang.String> namespaces = new HashMap<>();
+        for (var url : urls) {
+            var ns = getNamespaceKey(url);
+            if (ns != null) {
+                namespaces.put(ns, url);
+            }
+        }
+        return namespaces;
+    }
 
-	private java.lang.String getNamespaceKey(java.lang.String url) {
-		for (var entry : CimConstants.NAMESPACES_MAP.entrySet()) {
-			if (entry.getValue().equals(url)) {
-				return entry.getKey();
-			}
-		}
-		return null;
-	}
+    private java.lang.String getNamespaceKey(java.lang.String url) {
+        for (var entry : CimConstants.NAMESPACES_MAP.entrySet()) {
+            if (entry.getValue().equals(url)) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
 }

--- a/cimgen/languages/java/utils/RdfWriter.java
+++ b/cimgen/languages/java/utils/RdfWriter.java
@@ -129,6 +129,9 @@ public class RdfWriter {
                                 if (attrRdfId != null) {
                                     if (!attrRdfId.contains("#")) {
                                         attrRdfId = "#" + attrRdfId;
+                                    } else if (attrRdfId.indexOf("#") != 0) {
+                                        String[] parts = attrRdfId.split("#");
+                                        attrRdfId = namespaceUrl + parts[1];
                                     }
                                     writer.writeCharacters("\n    ");
                                     writer.writeEmptyElement(namespaceUrl, attrFullName);


### PR DESCRIPTION
- Change the reader to StAX XMLStreamReader (fixing too long parse time: > 5 hours for 25 MByte, now < 5 seconds :); add consumer function createCimObjectFunction to separate creation of CIM objects from parser code)
- Change the writer to StAX XMLStreamWriter
- Reformat all java sources (replacing tabs with spaces)
- Add generation of CimClassMap.java
- Prevent reader warnings while parsing the model description
- Fix wrong enum namespace in writer (e.g. rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" - ignore namespace read from source file - always write attribute namespace of generated enum class)
- Fix reading models from more than one file