### PR TITLE
Prepare parsing custom profiles

### DIFF
--- a/cimgen/build.py
+++ b/cimgen/build.py
@@ -1,6 +1,6 @@
 import argparse
 import importlib
-import os
+from pathlib import Path
 from types import ModuleType
 
 from cimgen import cimgen
@@ -21,7 +21,7 @@ def build() -> None:
     args = parser.parse_args()
 
     lang_pack: ModuleType = importlib.import_module(f"cimgen.languages.{args.langdir}.lang_pack")
-    schema_path = os.path.join(os.getcwd(), args.schemadir)
+    schema_path = Path.cwd() / args.schemadir
     cimgen.cim_generate(schema_path, args.outdir, args.cgmes_version, lang_pack)
 
 

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -443,6 +443,10 @@ def _write_all_files(
             "recommended_class_profile": recommended_class_profiles[class_name],
         }
 
+        # Exclude ModelDescription and DifferenceModel definitions
+        if class_details["class_namespace"] in (all_namespaces.get("md"), all_namespaces.get("dm")):
+            continue
+
         # extract comments
         if elem_dict[class_name].comment:
             class_details["class_comment"] = elem_dict[class_name].comment


### PR DESCRIPTION
- Read possible custom profiles in subdirectories of the schema directory (but main directory first)
- Prevent generating classes for ModelDescription and DifferenceModel definitions
- Skip attributes with wrong or missing class in rdf:about