### PR TITLE
Prepare parsing custom profiles - part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ export BUILD_IN_DOCKER=true
 make modernpython
 ```
 
+## Custom Profiles
+
+To generate files for custom profiles,
+you have to copy the profile files to a subdirectory of the schema directory.
+All profiles in the schema directory and its subdirectories are read,
+but the profiles in the main directory are read first.
+
+```bash
+mkdir cgmes_schema/<schemadir>/<customdir>/
+cp <custom_profile>.rdf ... cgmes_schema/<schemadir>/<customdir>/
+cimgen --outdir=output/ --schemadir=cgmes_schema/<schemadir> --langdir=<lang> --cgmes_version=<version>
+```
+
 ## Development
 
 ### Developer Installation

--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -335,6 +335,9 @@ def _add_class(classes_map: dict[str, CIMComponentDefinition], rdfs_entry: RDFSE
     """
     Add class component to classes map
     """
+    # Exclude DifferenceModel definitions
+    if rdfs_entry.namespace() == all_namespaces.get("dm"):
+        return
     if rdfs_entry.label() in classes_map:
         logger.error("Class {} already exists".format(rdfs_entry.label()))
     classes_map[rdfs_entry.label()] = CIMComponentDefinition(rdfs_entry)
@@ -876,6 +879,9 @@ def _check_attribute_for_class(classes_map: dict[str, CIMComponentDefinition], a
     :param attribute:   Dictionary with information about an attribute of a class.
     :return:            Is the attribute okay?
     """
+    # Exclude ModelDescription and DifferenceModel definitions
+    if attribute["namespace"] in (all_namespaces.get("md"), all_namespaces.get("dm")):
+        return False
     about = attribute["about"]
     domain = attribute["domain"]
     label = attribute["label"]


### PR DESCRIPTION
- Prevent generating classes for ModelDescription and DifferenceModel definitions earlier (to prevent collisions with class DifferenceModel from namespace http://entsoe.eu/ns/nc#)
- Add description how to generate files for custom profiles to Readme.md