### PR TITLE
Fix entity references in java reader

### DIFF
--- a/cimgen/languages/java/utils/RdfWriter.java
+++ b/cimgen/languages/java/utils/RdfWriter.java
@@ -381,7 +381,7 @@ public class RdfWriter {
         if (profiles != null && profiles.contains(classProfile)) {
             return classProfile;
         }
-        if (!profiles.isEmpty()) {
+        if (profiles != null && !profiles.isEmpty()) {
             var list = new ArrayList<CGMESProfile>(profiles);
             Collections.sort(list);
             return list.get(0);


### PR DESCRIPTION
- Fix reading text with entity references in java reader
  - If an XML text value contains entity references the text is splitted into several events and has to be concatenated to get the full text value.
  - Some entity references are replaced, like `&lt;` ->`<`, `&gt;` ->`>` etc. and provided as CHARACTERS event.
  - Other (unknown) entitity references are provided as ENTITY_REFERENCE event without `&` and `;`.
- Fix null pointer exception in RdfWriter.getAttributeProfile()