### PR TITLE
Improve java

### DIFF
--- a/cimgen/languages/java/BaseClass.java
+++ b/cimgen/languages/java/BaseClass.java
@@ -13,10 +13,22 @@ import java.util.function.Function;
  * The rdfid is a unique identifier inside of a CIM model.
  * The cimType is the name of the real class of the CIM object - a subclass of
  * BaseClass.
+ * The rdfid and cimType are fixed after creation of a CIM object.
  */
 public abstract class BaseClass {
 
     private static final Logging LOG = Logging.getLogger(BaseClass.class);
+
+    /**
+     * Constructor for subclasses.
+     *
+     * @param cimType The name of the CIM type.
+     * @param rdfid   The RDF ID of the CIM object read from rdf:ID or rdf:about.
+     */
+    protected BaseClass(String cimType, String rdfid) {
+        this.cimType = cimType;
+        this.rdfid = rdfid;
+    }
 
     /**
      * The name of the CIM type.
@@ -27,10 +39,6 @@ public abstract class BaseClass {
         return cimType;
     }
 
-    public void setCimType(String cimType) {
-        this.cimType = cimType;
-    }
-
     /**
      * The RDF ID of the CIM object read from rdf:ID or rdf:about.
      */
@@ -38,10 +46,6 @@ public abstract class BaseClass {
 
     public String getRdfid() {
         return rdfid;
-    }
-
-    public void setRdfid(String rdfid) {
-        this.rdfid = rdfid;
     }
 
     /**

--- a/cimgen/languages/java/BaseClass.java
+++ b/cimgen/languages/java/BaseClass.java
@@ -107,28 +107,20 @@ public abstract class BaseClass {
     public abstract String getAttributeFullName(String attrName);
 
     /**
-     * Get an attribute value as string.
+     * Get an attribute value.
      *
      * @param attrName The attribute name
      * @return         The attribute value
      */
-    public abstract String getAttribute(String attrName);
+    public abstract Object getAttribute(String attrName);
 
     /**
-     * Set an attribute value as object (for class and list attributes).
+     * Set an attribute value.
      *
-     * @param attrName    The attribute name
-     * @param objectValue The attribute value as object
+     * @param attrName The attribute name
+     * @param value    The attribute value
      */
-    public abstract void setAttribute(String attrName, BaseClass objectValue);
-
-    /**
-     * Set an attribute value as string (for primitive (including datatype) and enum attributes).
-     *
-     * @param attrName    The attribute name
-     * @param stringValue The attribute value as string
-     */
-    public abstract void setAttribute(String attrName, String stringValue);
+    public abstract void setAttribute(String attrName, Object value);
 
     /**
      * Check if the attribute is a primitive attribute.
@@ -213,11 +205,11 @@ public abstract class BaseClass {
      * Helper functions.
      */
 
-    protected Boolean getBooleanFromString(String stringValue) {
+    protected static Boolean getBooleanFromString(String stringValue) {
         return stringValue.toLowerCase().equals("true");
     }
 
-    protected Double getDoubleFromString(String stringValue) {
+    protected static Double getDoubleFromString(String stringValue) {
         try {
             return Double.valueOf(stringValue);
         } catch (NumberFormatException ex) {
@@ -226,7 +218,7 @@ public abstract class BaseClass {
         }
     }
 
-    protected Float getFloatFromString(String stringValue) {
+    protected static Float getFloatFromString(String stringValue) {
         try {
             return Float.valueOf(stringValue);
         } catch (NumberFormatException ex) {
@@ -235,7 +227,7 @@ public abstract class BaseClass {
         }
     }
 
-    protected Integer getIntegerFromString(String stringValue) {
+    protected static Integer getIntegerFromString(String stringValue) {
         try {
             return Integer.parseInt(stringValue.trim());
         } catch (NumberFormatException ex) {
@@ -244,24 +236,13 @@ public abstract class BaseClass {
         }
     }
 
-    protected String getStringFromSet(Set<? extends BaseClass> set) {
-        if (!set.isEmpty()) {
-            String references = "";
-            for (var obj : set) {
-                references += obj.getRdfid() + " ";
-            }
-            return references.trim();
-        }
-        return null;
-    }
-
     /**
      * Nested helper classes.
      */
 
     protected static class AttrDetails {
         public AttrDetails(String f, boolean u, String n, Set<CGMESProfile> c, boolean p, boolean e,
-                Function<BaseClass, String> g, BiConsumer<BaseClass, BaseClass> o, BiConsumer<BaseClass, String> s) {
+                Function<BaseClass, Object> g, BiConsumer<BaseClass, Object> s) {
             fullName = f;
             isUsed = u;
             nameSpace = n;
@@ -269,8 +250,7 @@ public abstract class BaseClass {
             isPrimitive = p;
             isEnum = e;
             getter = g;
-            objectSetter = o;
-            stringSetter = s;
+            setter = s;
         }
 
         public String fullName;
@@ -279,8 +259,7 @@ public abstract class BaseClass {
         public Set<CGMESProfile> profiles;
         public Boolean isPrimitive;
         public Boolean isEnum;
-        public Function<BaseClass, String> getter;
-        public BiConsumer<BaseClass, BaseClass> objectSetter;
-        public BiConsumer<BaseClass, String> stringSetter;
+        public Function<BaseClass, Object> getter;
+        public BiConsumer<BaseClass, Object> setter;
     }
 }

--- a/cimgen/languages/java/BaseClass.java
+++ b/cimgen/languages/java/BaseClass.java
@@ -3,8 +3,8 @@ package cim4j;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * Base class of the CIM type hierarchy - all not primitive CIM classes inherit
@@ -110,11 +110,6 @@ public abstract class BaseClass {
      */
     public abstract String getAttribute(String attrName);
 
-    protected String getAttribute(String className, String attrName) {
-        LOG.error(String.format("No-one knows an attribute %s.%s", className, attrName));
-        return "";
-    }
-
     /**
      * Set an attribute value as object (for class and list attributes).
      *
@@ -123,11 +118,6 @@ public abstract class BaseClass {
      */
     public abstract void setAttribute(String attrName, BaseClass objectValue);
 
-    protected void setAttribute(String className, String attrName, BaseClass objectValue) {
-        LOG.error(String.format("No-one knows what to do with attribute %s.%s and value %s", className, attrName,
-                objectValue));
-    }
-
     /**
      * Set an attribute value as string (for primitive (including datatype) and enum attributes).
      *
@@ -135,11 +125,6 @@ public abstract class BaseClass {
      * @param stringValue The attribute value as string
      */
     public abstract void setAttribute(String attrName, String stringValue);
-
-    protected void setAttribute(String className, String attrName, String stringValue) {
-        LOG.error(String.format("No-one knows what to do with attribute %s.%s and value %s", className, attrName,
-                stringValue));
-    }
 
     /**
      * Check if the attribute is a primitive attribute.
@@ -271,13 +256,17 @@ public abstract class BaseClass {
      */
 
     protected static class AttrDetails {
-        public AttrDetails(String f, boolean u, String n, Set<CGMESProfile> c, boolean p, boolean e) {
+        public AttrDetails(String f, boolean u, String n, Set<CGMESProfile> c, boolean p, boolean e,
+                Function<BaseClass, String> g, BiConsumer<BaseClass, BaseClass> o, BiConsumer<BaseClass, String> s) {
             fullName = f;
             isUsed = u;
             nameSpace = n;
             profiles = c;
             isPrimitive = p;
             isEnum = e;
+            getter = g;
+            objectSetter = o;
+            stringSetter = s;
         }
 
         public String fullName;
@@ -286,17 +275,8 @@ public abstract class BaseClass {
         public Set<CGMESProfile> profiles;
         public Boolean isPrimitive;
         public Boolean isEnum;
-    }
-
-    protected static class GetterSetter {
-        public GetterSetter(Supplier<String> g, Consumer<BaseClass> o, Consumer<String> s) {
-            getter = g;
-            objectSetter = o;
-            stringSetter = s;
-        }
-
-        public Supplier<String> getter;
-        public Consumer<BaseClass> objectSetter;
-        public Consumer<String> stringSetter;
+        public Function<BaseClass, String> getter;
+        public BiConsumer<BaseClass, BaseClass> objectSetter;
+        public BiConsumer<BaseClass, String> stringSetter;
     }
 }

--- a/cimgen/languages/java/BaseClass.java
+++ b/cimgen/languages/java/BaseClass.java
@@ -25,7 +25,7 @@ public abstract class BaseClass {
      * @param cimType The name of the CIM type.
      * @param rdfid   The RDF ID of the CIM object read from rdf:ID or rdf:about.
      */
-    protected BaseClass(String cimType, String rdfid) {
+    protected BaseClass(final String cimType, final String rdfid) {
         this.cimType = cimType;
         this.rdfid = rdfid;
     }
@@ -33,7 +33,7 @@ public abstract class BaseClass {
     /**
      * The name of the CIM type.
      */
-    private String cimType;
+    private final String cimType;
 
     public String getCimType() {
         return cimType;
@@ -42,7 +42,7 @@ public abstract class BaseClass {
     /**
      * The RDF ID of the CIM object read from rdf:ID or rdf:about.
      */
-    private String rdfid;
+    private final String rdfid;
 
     public String getRdfid() {
         return rdfid;
@@ -80,6 +80,16 @@ public abstract class BaseClass {
         int result = 1;
         result = (result * PRIME) + (rdfid == null ? 0 : rdfid.hashCode());
         return result;
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return  a string representation of the object.
+     */
+    @Override
+    public final String toString() {
+       return cimType + " with rdfid " + rdfid;
     }
 
     /**

--- a/cimgen/languages/java/Logging.java
+++ b/cimgen/languages/java/Logging.java
@@ -1,5 +1,7 @@
 package cim4j;
 
+import java.time.LocalDateTime;
+
 // import org.apache.logging.log4j.LogManager;
 // import org.apache.logging.log4j.Logger;
 
@@ -19,6 +21,7 @@ public class Logging {
         trace
     }
 
+    private static Level defaultLevel = Level.error;
     private Level level;
     private String className;
     // private Logger log4jLogger;
@@ -33,7 +36,7 @@ public class Logging {
 
     private void log(Level logLevel, String message) {
         if (printlnEnabled && logLevel.compareTo(level) <= 0) {
-            System.out.println(className + " " + logLevel + ": " + message);
+            System.out.println(LocalDateTime.now() + " " + className + " " + logLevel + ": " + message);
         }
     }
 
@@ -44,7 +47,7 @@ public class Logging {
      * @param clazz The Class whose name should be used as the Logger name.
      */
     public static Logging getLogger(final Class<?> clazz) {
-        return new Logging(clazz, Level.error);
+        return new Logging(clazz, defaultLevel);
     }
 
     /**
@@ -76,6 +79,24 @@ public class Logging {
     public static void setEnabled(boolean enabled) {
         log4jEnabled = enabled;
         printlnEnabled = enabled;
+    }
+
+    /**
+     * Returns the default log level.
+     *
+     * @return default log level
+     */
+    public static Level getDefaultLogLevel() {
+        return defaultLevel;
+    }
+
+    /**
+     * Sets the default log level.
+     *
+     * @param level Log level.
+     */
+    public static void setDefaultLogLevel(Level level) {
+        defaultLevel = level;
     }
 
     /**

--- a/cimgen/languages/java/Logging.java
+++ b/cimgen/languages/java/Logging.java
@@ -25,7 +25,8 @@ public class Logging {
     private Level level;
     private String className;
     // private Logger log4jLogger;
-    private static boolean log4jEnabled = true;
+    // private static boolean log4jEnabled = true;
+    private static boolean log4jEnabled = false;
     private static boolean printlnEnabled = true;
 
     private Logging(final Class<?> clazz, Level logLevel) {
@@ -77,7 +78,7 @@ public class Logging {
      * @param enabled logging enabled
      */
     public static void setEnabled(boolean enabled) {
-        log4jEnabled = enabled;
+        // log4jEnabled = enabled;
         printlnEnabled = enabled;
     }
 

--- a/cimgen/languages/java/lang_pack.py
+++ b/cimgen/languages/java/lang_pack.py
@@ -54,7 +54,7 @@ def run_template(output_path: str, class_details: dict) -> None:
                 attribute["primitive_java_type"] = "Float"
             else:
                 attribute["primitive_java_type"] = attribute["attribute_class"]
-        attribute["variable_name"] = _variable_name(attribute["label"])
+        attribute["variable_name"] = _variable_name(attribute["label"], class_details["class_name"])
         attribute["getter_name"] = _getter_setter_name("get", attribute["label"])
         attribute["setter_name"] = _getter_setter_name("set", attribute["label"])
         if attribute["is_class_attribute"] or attribute["is_list_attribute"]:
@@ -102,15 +102,17 @@ def _create_cgmes_profile(output_path: Path, profile_details: list[dict]) -> Non
     _write_templated_file(class_file, class_details, profile_template_file["filename"])
 
 
-def _variable_name(label: str) -> str:
+def _variable_name(label: str, class_name: str) -> str:
     """Get the name of the label used as variable name.
 
     Some label names are not allowed as name of a variable.
+    Prevent collision of label and class_name (e.g. AvailabilitySchedule in profile AvailabilitySchedule).
 
-    :param label:  Original label
-    :return:       Variable name
+    :param label:       Original label
+    :param class_name:  Original class name
+    :return:            Variable name
     """
-    if label == "switch":
+    if label == "switch" or label == class_name:
         label += "_"
     return label
 

--- a/cimgen/languages/java/main/Main.java
+++ b/cimgen/languages/java/main/Main.java
@@ -67,6 +67,9 @@ public final class Main {
         checkArgs(inputFiles);
 
         readRdfWriteRdf(inputFiles, outputFile);
+
+        LOG.info(String.format("Total allocated memory: %d of %d MByte",
+                Runtime.getRuntime().totalMemory() / (1024 * 1024), Runtime.getRuntime().maxMemory() / (1024 * 1024)));
     }
 
     /**

--- a/cimgen/languages/java/main/Main.java
+++ b/cimgen/languages/java/main/Main.java
@@ -14,34 +14,55 @@ import cim4j.utils.RdfWriter;
  */
 public final class Main {
 
-    private static final Logging LOG = Logging.getLogger(Main.class);
+    private static Logging LOG = Logging.getLogger(Main.class);
 
     // Private dummy constructor - prevent to instantiate the class at all
     private Main() {
     }
 
-    private static void printUsageAndExit(String aError) {
-        if (!aError.isEmpty()) {
-            System.out.println("\nError: " + aError);
+    private static void printUsageAndExit(String error) {
+        if (!error.isEmpty()) {
+            System.out.println("\nError: " + error);
         }
         System.out.println("\nRead RDF files and write the data to RDF files separated by profiles.\n");
-        System.out.println("Usage: java -jar cim4j.jar <rdf_file>  [<rdf_file>  ...] <output_path_stem>");
+        System.out.println("Usage: java -jar cim4j.jar [--log-level <level>] <rdf_file> [<rdf_file> ...]" +
+                " <output_path_stem>");
+        System.out.println("       --log-level <level>  Log level (fatal, error, warn, info, debug, trace)");
+        System.out.println("                            Default log level: error");
+        System.out.println("       <rdf_file> ...       Input files with CIM/CGMES data");
+        System.out.println("       <output_path_stem>   Stem of the output files" +
+                " (<output_path_stem>_<profile_name>.xml)");
         System.exit(2);
     }
 
     /**
      * Main function of the cim4j application.
      */
-    public static void main(String[] aArgs) {
-        if (aArgs.length < 2) {
+    public static void main(String[] args) {
+        int offset = 0;
+        if (args.length >= 2 && args[0].equals("--log-level")) {
+            Logging.Level level = Logging.getDefaultLogLevel();
+            try {
+                level = Logging.Level.valueOf(args[1]);
+            } catch (IllegalArgumentException ex) {
+                printUsageAndExit("unknown log level: " + args[1]);
+            }
+            if (!level.equals(Logging.getDefaultLogLevel())) {
+                Logging.setDefaultLogLevel(level);
+                LOG = Logging.getLogger(Main.class);
+            }
+            offset += 2;
+        }
+
+        if (args.length < offset + 2) {
             printUsageAndExit("too few arguments");
         }
 
         List<String> inputFiles = new ArrayList<>();
-        for (int idx = 0; idx < aArgs.length - 1; ++idx) {
-            inputFiles.add(aArgs[idx]);
+        for (int idx = offset; idx < args.length - 1; ++idx) {
+            inputFiles.add(args[idx]);
         }
-        String outputFile = aArgs[aArgs.length - 1];
+        String outputFile = args[args.length - 1];
 
         checkArgs(inputFiles);
 
@@ -70,7 +91,14 @@ public final class Main {
     public static Map<String, BaseClass> readRdf(List<String> inputFiles) {
         try {
             var rdfReader = new RdfReader();
-            return rdfReader.read(inputFiles);
+            int count = 0;
+            for (var file : inputFiles) {
+                ++count;
+                LOG.info(String.format("CIM inputfile %d: %s", count, file));
+            }
+            var cimData = rdfReader.read(inputFiles);
+            LOG.info(String.format("Read %d inputfiles", count));
+            return cimData;
         } catch (Exception ex) {
             LOG.error("Failed to convert RDF files to CIM", ex);
             return null;
@@ -94,6 +122,7 @@ public final class Main {
                 ++count;
                 LOG.info(String.format("CIM outputfile %d: %s", count, profileFileMap.get(profile)));
             }
+            LOG.info(String.format("Written %d outputfiles", count));
         } catch (Exception ex) {
             LOG.error("Failed to write CIM data to a RDF file", ex);
             return;

--- a/cimgen/languages/java/templates/java_class.mustache
+++ b/cimgen/languages/java/templates/java_class.mustache
@@ -61,6 +61,14 @@ public class {{class_name}} extends {{subclass_of}} {
     public String {{label}}ToString() {
         return {{variable_name}} != null ? {{variable_name}}.toString() : null;
     }
+
+    private static void {{setter_name}}(BaseClass _this_, String _value_) {
+        (({{class_name}}) _this_).{{setter_name}}(_value_);
+    }
+
+    private static String {{label}}ToString(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{label}}ToString();
+    }
 {{/is_primitive_attribute}}
 {{#is_datatype_attribute}}
     private Double {{variable_name}}; // {{attribute_class}}
@@ -80,6 +88,14 @@ public class {{class_name}} extends {{subclass_of}} {
     public String {{label}}ToString() {
         return {{variable_name}} != null ? {{variable_name}}.toString() : null;
     }
+
+    private static void {{setter_name}}(BaseClass _this_, String _value_) {
+        (({{class_name}}) _this_).{{setter_name}}(_value_);
+    }
+
+    private static String {{label}}ToString(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{label}}ToString();
+    }
 {{/is_datatype_attribute}}
 {{#is_enum_attribute}}
     private String {{variable_name}}; // {{attribute_class}}
@@ -94,6 +110,14 @@ public class {{class_name}} extends {{subclass_of}} {
 
     public String {{label}}ToString() {
         return {{variable_name}};
+    }
+
+    private static void {{setter_name}}(BaseClass _this_, String _value_) {
+        (({{class_name}}) _this_).{{setter_name}}(_value_);
+    }
+
+    private static String {{label}}ToString(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{label}}ToString();
     }
 {{/is_enum_attribute}}
 {{#is_class_attribute}}
@@ -123,6 +147,14 @@ public class {{class_name}} extends {{subclass_of}} {
     public String {{label}}ToString() {
         return {{variable_name}} != null ? {{variable_name}}.getRdfid() : null;
     }
+
+    private static void {{setter_name}}(BaseClass _this_, BaseClass _object_) {
+        (({{class_name}}) _this_).{{setter_name}}(_object_);
+    }
+
+    private static String {{label}}ToString(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{label}}ToString();
+    }
 {{/is_class_attribute}}
 {{#is_list_attribute}}
     private Set<{{attribute_class}}> {{variable_name}} = new HashSet<>(); // OneToMany
@@ -145,6 +177,14 @@ public class {{class_name}} extends {{subclass_of}} {
 
     public String {{label}}ToString() {
         return getStringFromSet({{variable_name}});
+    }
+
+    private static void {{setter_name}}(BaseClass _this_, BaseClass _object_) {
+        (({{class_name}}) _this_).{{setter_name}}(_object_);
+    }
+
+    private static String {{label}}ToString(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{label}}ToString();
     }
 {{/is_list_attribute}}
 {{/attributes}}
@@ -190,16 +230,12 @@ public class {{class_name}} extends {{subclass_of}} {
      */
     @Override
     public String getAttribute(String attrName) {
-        return getAttribute("{{class_name}}", attrName);
-    }
-
-    @Override
-    protected String getAttribute(String className, String attrName) {
-        if (classGetterSetterMap.containsKey(attrName)) {
-            var getterFunction = classGetterSetterMap.get(attrName).getter;
-            return getterFunction.get();
+        if (ATTR_DETAILS_MAP.containsKey(attrName)) {
+            var getterFunction = ATTR_DETAILS_MAP.get(attrName).getter;
+            return getterFunction.apply(this);
         }
-        return super.getAttribute(className, attrName);
+        LOG.error(String.format("No-one knows an attribute %s.%s", "{{class_name}}", attrName));
+        return "";
     }
 
     /**
@@ -210,16 +246,12 @@ public class {{class_name}} extends {{subclass_of}} {
      */
     @Override
     public void setAttribute(String attrName, BaseClass objectValue) {
-        setAttribute("{{class_name}}", attrName, objectValue);
-    }
-
-    @Override
-    protected void setAttribute(String className, String attrName, BaseClass objectValue) {
-        if (classGetterSetterMap.containsKey(attrName)) {
-            var setterFunction = classGetterSetterMap.get(attrName).objectSetter;
-            setterFunction.accept(objectValue);
+        if (ATTR_DETAILS_MAP.containsKey(attrName)) {
+            var setterFunction = ATTR_DETAILS_MAP.get(attrName).objectSetter;
+            setterFunction.accept(this, objectValue);
         } else {
-            super.setAttribute(className, attrName, objectValue);
+            LOG.error(String.format("No-one knows what to do with attribute %s.%s and value %s",
+                "{{class_name}}", attrName, objectValue));
         }
     }
 
@@ -231,16 +263,12 @@ public class {{class_name}} extends {{subclass_of}} {
      */
     @Override
     public void setAttribute(String attrName, String stringValue) {
-        setAttribute("{{class_name}}", attrName, stringValue);
-    }
-
-    @Override
-    protected void setAttribute(String className, String attrName, String stringValue) {
-        if (classGetterSetterMap.containsKey(attrName)) {
-            var setterFunction = classGetterSetterMap.get(attrName).stringSetter;
-            setterFunction.accept(stringValue);
+        if (ATTR_DETAILS_MAP.containsKey(attrName)) {
+            var setterFunction = ATTR_DETAILS_MAP.get(attrName).stringSetter;
+            setterFunction.accept(this, stringValue);
         } else {
-            super.setAttribute(className, attrName, stringValue);
+            LOG.error(String.format("No-one knows what to do with attribute %s.%s and value %s",
+                "{{class_name}}", attrName, stringValue));
         }
     }
 
@@ -368,28 +396,28 @@ public class {{class_name}} extends {{subclass_of}} {
             profiles.add(CGMESProfile.{{origin}});
 {{/attr_origin}}
 {{#is_primitive_attribute}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, true, false));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, true, false, {{class_name}}::{{label}}ToString, null, {{class_name}}::{{setter_name}}));
 {{/is_primitive_attribute}}
 {{#is_datatype_attribute}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, true, false));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, true, false, {{class_name}}::{{label}}ToString, null, {{class_name}}::{{setter_name}}));
 {{/is_datatype_attribute}}
 {{#is_enum_attribute}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, true));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, true, {{class_name}}::{{label}}ToString, null, {{class_name}}::{{setter_name}}));
 {{/is_enum_attribute}}
 {{#is_class_attribute}}
 {{#is_used}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, false));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{label}}ToString, {{class_name}}::{{setter_name}}, null));
 {{/is_used}}
 {{^is_used}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", false, "{{attribute_namespace}}", profiles, false, false));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", false, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{label}}ToString, {{class_name}}::{{setter_name}}, null));
 {{/is_used}}
 {{/is_class_attribute}}
 {{#is_list_attribute}}
 {{#is_used}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, false));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{label}}ToString, {{class_name}}::{{setter_name}}, null));
 {{/is_used}}
 {{^is_used}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", false, "{{attribute_namespace}}", profiles, false, false));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", false, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{label}}ToString, {{class_name}}::{{setter_name}}, null));
 {{/is_used}}
 {{/is_list_attribute}}
         }
@@ -397,29 +425,6 @@ public class {{class_name}} extends {{subclass_of}} {
         CLASS_ATTR_DETAILS_MAP = map;
         ATTR_DETAILS_MAP = Collections.unmodifiableMap(new {{class_name}}().allAttrDetailsMap());
         ATTR_NAMES_LIST = new ArrayList<>(ATTR_DETAILS_MAP.keySet());
-    }
-
-    private final Map<String, GetterSetter> classGetterSetterMap = fillGetterSetterMap();
-    private final Map<String, GetterSetter> fillGetterSetterMap() {
-        Map<String, GetterSetter> map = new LinkedHashMap<>();
-{{#attributes}}
-{{#is_primitive_attribute}}
-        map.put("{{label}}", new GetterSetter(this::{{label}}ToString, null, this::{{setter_name}}));
-{{/is_primitive_attribute}}
-{{#is_datatype_attribute}}
-        map.put("{{label}}", new GetterSetter(this::{{label}}ToString, null, this::{{setter_name}}));
-{{/is_datatype_attribute}}
-{{#is_enum_attribute}}
-        map.put("{{label}}", new GetterSetter(this::{{label}}ToString, null, this::{{setter_name}}));
-{{/is_enum_attribute}}
-{{#is_class_attribute}}
-        map.put("{{label}}", new GetterSetter(this::{{label}}ToString, this::{{setter_name}}, null));
-{{/is_class_attribute}}
-{{#is_list_attribute}}
-        map.put("{{label}}", new GetterSetter(this::{{label}}ToString, this::{{setter_name}}, null));
-{{/is_list_attribute}}
-{{/attributes}}
-        return map;
     }
 
     private static final Set<CGMESProfile> POSSIBLE_PROFILES;

--- a/cimgen/languages/java/templates/java_class.mustache
+++ b/cimgen/languages/java/templates/java_class.mustache
@@ -58,24 +58,31 @@ public class {{class_name}} extends {{subclass_of}} {
     public void {{setter_name}}({{primitive_java_type}} _value_) {
         {{variable_name}} = _value_;
     }
-{{^is_primitive_string}}
 
-    public void {{setter_name}}(String _value_) {
-        {{variable_name}} = get{{primitive_java_type}}FromString(_value_);
+    private static Object {{getter_name}}(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{getter_name}}();
+    }
+
+{{#is_primitive_string}}
+    private static void {{setter_name}}(BaseClass _this_, Object _value_) {
+        if (_value_ instanceof String) {
+            (({{class_name}}) _this_).{{setter_name}}((String) _value_);
+        } else {
+            throw new IllegalArgumentException("Object is not String");
+        }
     }
 {{/is_primitive_string}}
-
-    public String {{label}}ToString() {
-        return {{variable_name}} != null ? {{variable_name}}.toString() : null;
+{{^is_primitive_string}}
+    private static void {{setter_name}}(BaseClass _this_, Object _value_) {
+        if (_value_ instanceof {{primitive_java_type}}) {
+            (({{class_name}}) _this_).{{setter_name}}(({{primitive_java_type}}) _value_);
+        } else if (_value_ instanceof String) {
+            (({{class_name}}) _this_).{{setter_name}}(get{{primitive_java_type}}FromString((String) _value_));
+        } else {
+            throw new IllegalArgumentException("Object is neither {{primitive_java_type}} nor String");
+        }
     }
-
-    private static void {{setter_name}}(BaseClass _this_, String _value_) {
-        (({{class_name}}) _this_).{{setter_name}}(_value_);
-    }
-
-    private static String {{label}}ToString(BaseClass _this_) {
-        return (({{class_name}}) _this_).{{label}}ToString();
-    }
+{{/is_primitive_string}}
 {{/is_primitive_attribute}}
 {{#is_datatype_attribute}}
     private Double {{variable_name}}; // {{attribute_class}}
@@ -88,20 +95,18 @@ public class {{class_name}} extends {{subclass_of}} {
         {{variable_name}} = _value_;
     }
 
-    public void {{setter_name}}(String _value_) {
-        {{variable_name}} = getDoubleFromString(_value_);
+    private static Object {{getter_name}}(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{getter_name}}();
     }
 
-    public String {{label}}ToString() {
-        return {{variable_name}} != null ? {{variable_name}}.toString() : null;
-    }
-
-    private static void {{setter_name}}(BaseClass _this_, String _value_) {
-        (({{class_name}}) _this_).{{setter_name}}(_value_);
-    }
-
-    private static String {{label}}ToString(BaseClass _this_) {
-        return (({{class_name}}) _this_).{{label}}ToString();
+    private static void {{setter_name}}(BaseClass _this_, Object _value_) {
+        if (_value_ instanceof Double) {
+            (({{class_name}}) _this_).{{setter_name}}((Double) _value_);
+        } else if (_value_ instanceof String) {
+            (({{class_name}}) _this_).{{setter_name}}(getDoubleFromString((String) _value_));
+        } else {
+            throw new IllegalArgumentException("Object is neither Double nor String");
+        }
     }
 {{/is_datatype_attribute}}
 {{#is_enum_attribute}}
@@ -115,16 +120,16 @@ public class {{class_name}} extends {{subclass_of}} {
         {{variable_name}} = _value_;
     }
 
-    public String {{label}}ToString() {
-        return {{variable_name}};
+    private static Object {{getter_name}}(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{getter_name}}();
     }
 
-    private static void {{setter_name}}(BaseClass _this_, String _value_) {
-        (({{class_name}}) _this_).{{setter_name}}(_value_);
-    }
-
-    private static String {{label}}ToString(BaseClass _this_) {
-        return (({{class_name}}) _this_).{{label}}ToString();
+    private static void {{setter_name}}(BaseClass _this_, Object _value_) {
+        if (_value_ instanceof String) {
+            (({{class_name}}) _this_).{{setter_name}}((String) _value_);
+        } else {
+            throw new IllegalArgumentException("Object is not String");
+        }
     }
 {{/is_enum_attribute}}
 {{#is_class_attribute}}
@@ -139,28 +144,25 @@ public class {{class_name}} extends {{subclass_of}} {
         return {{variable_name}};
     }
 
-    public void {{setter_name}}(BaseClass _object_) {
-        if (!(_object_ instanceof {{attribute_class}})) {
-            throw new IllegalArgumentException("Object is not {{attribute_class}}");
-        }
+    public void {{setter_name}}({{attribute_class}} _object_) {
         if ({{variable_name}} != _object_) {
-            {{variable_name}} = ({{attribute_class}}) _object_;
+            {{variable_name}} = _object_;
 {{#inverse_setter}}
             {{variable_name}}.{{.}}(this);
 {{/inverse_setter}}
         }
     }
 
-    public String {{label}}ToString() {
-        return {{variable_name}} != null ? {{variable_name}}.getRdfid() : null;
+    private static Object {{getter_name}}(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{getter_name}}();
     }
 
-    private static void {{setter_name}}(BaseClass _this_, BaseClass _object_) {
-        (({{class_name}}) _this_).{{setter_name}}(_object_);
-    }
-
-    private static String {{label}}ToString(BaseClass _this_) {
-        return (({{class_name}}) _this_).{{label}}ToString();
+    private static void {{setter_name}}(BaseClass _this_, Object _value_) {
+        if (_value_ instanceof {{attribute_class}}) {
+            (({{class_name}}) _this_).{{setter_name}}(({{attribute_class}}) _value_);
+        } else {
+            throw new IllegalArgumentException("Object is not {{attribute_class}}");
+        }
     }
 {{/is_class_attribute}}
 {{#is_list_attribute}}
@@ -170,28 +172,25 @@ public class {{class_name}} extends {{subclass_of}} {
         return {{variable_name}};
     }
 
-    public void {{setter_name}}(BaseClass _object_) {
-        if (!(_object_ instanceof {{attribute_class}})) {
-            throw new IllegalArgumentException("Object is not {{attribute_class}}");
-        }
+    public void {{setter_name}}({{attribute_class}} _object_) {
         if (!{{variable_name}}.contains(_object_)) {
-            {{variable_name}}.add(({{attribute_class}}) _object_);
+            {{variable_name}}.add(_object_);
 {{#inverse_setter}}
-            (({{attribute_class}}) _object_).{{.}}(this);
+            _object_.{{.}}(this);
 {{/inverse_setter}}
         }
     }
 
-    public String {{label}}ToString() {
-        return getStringFromSet({{variable_name}});
+    private static Object {{getter_name}}(BaseClass _this_) {
+        return (({{class_name}}) _this_).{{getter_name}}();
     }
 
-    private static void {{setter_name}}(BaseClass _this_, BaseClass _object_) {
-        (({{class_name}}) _this_).{{setter_name}}(_object_);
-    }
-
-    private static String {{label}}ToString(BaseClass _this_) {
-        return (({{class_name}}) _this_).{{label}}ToString();
+    private static void {{setter_name}}(BaseClass _this_, Object _value_) {
+        if (_value_ instanceof {{attribute_class}}) {
+            (({{class_name}}) _this_).{{setter_name}}(({{attribute_class}}) _value_);
+        } else {
+            throw new IllegalArgumentException("Object is not {{attribute_class}}");
+        }
     }
 {{/is_list_attribute}}
 {{/attributes}}
@@ -230,13 +229,13 @@ public class {{class_name}} extends {{subclass_of}} {
     }
 
     /**
-     * Get an attribute value as string.
+     * Get an attribute value.
      *
      * @param attrName The attribute name
      * @return         The attribute value
      */
     @Override
-    public String getAttribute(String attrName) {
+    public Object getAttribute(String attrName) {
         if (ATTR_DETAILS_MAP.containsKey(attrName)) {
             var getterFunction = ATTR_DETAILS_MAP.get(attrName).getter;
             return getterFunction.apply(this);
@@ -246,36 +245,19 @@ public class {{class_name}} extends {{subclass_of}} {
     }
 
     /**
-     * Set an attribute value as object (for class and list attributes).
+     * Set an attribute value.
      *
-     * @param attrName    The attribute name
-     * @param objectValue The attribute value as object
+     * @param attrName The attribute name
+     * @param value    The attribute value
      */
     @Override
-    public void setAttribute(String attrName, BaseClass objectValue) {
+    public void setAttribute(String attrName, Object value) {
         if (ATTR_DETAILS_MAP.containsKey(attrName)) {
-            var setterFunction = ATTR_DETAILS_MAP.get(attrName).objectSetter;
-            setterFunction.accept(this, objectValue);
+            var setterFunction = ATTR_DETAILS_MAP.get(attrName).setter;
+            setterFunction.accept(this, value);
         } else {
             LOG.error(String.format("No-one knows what to do with attribute %s.%s and value %s",
-                "{{class_name}}", attrName, objectValue));
-        }
-    }
-
-    /**
-     * Set an attribute value as string (for primitive (including datatype) and enum attributes).
-     *
-     * @param attrName    The attribute name
-     * @param stringValue The attribute value as string
-     */
-    @Override
-    public void setAttribute(String attrName, String stringValue) {
-        if (ATTR_DETAILS_MAP.containsKey(attrName)) {
-            var setterFunction = ATTR_DETAILS_MAP.get(attrName).stringSetter;
-            setterFunction.accept(this, stringValue);
-        } else {
-            LOG.error(String.format("No-one knows what to do with attribute %s.%s and value %s",
-                "{{class_name}}", attrName, stringValue));
+                "{{class_name}}", attrName, value));
         }
     }
 
@@ -403,28 +385,28 @@ public class {{class_name}} extends {{subclass_of}} {
             profiles.add(CGMESProfile.{{origin}});
 {{/attr_origin}}
 {{#is_primitive_attribute}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, true, false, {{class_name}}::{{label}}ToString, null, {{class_name}}::{{setter_name}}));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, true, false, {{class_name}}::{{getter_name}}, {{class_name}}::{{setter_name}}));
 {{/is_primitive_attribute}}
 {{#is_datatype_attribute}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, true, false, {{class_name}}::{{label}}ToString, null, {{class_name}}::{{setter_name}}));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, true, false, {{class_name}}::{{getter_name}}, {{class_name}}::{{setter_name}}));
 {{/is_datatype_attribute}}
 {{#is_enum_attribute}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, true, {{class_name}}::{{label}}ToString, null, {{class_name}}::{{setter_name}}));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, true, {{class_name}}::{{getter_name}}, {{class_name}}::{{setter_name}}));
 {{/is_enum_attribute}}
 {{#is_class_attribute}}
 {{#is_used}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{label}}ToString, {{class_name}}::{{setter_name}}, null));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{getter_name}}, {{class_name}}::{{setter_name}}));
 {{/is_used}}
 {{^is_used}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", false, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{label}}ToString, {{class_name}}::{{setter_name}}, null));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", false, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{getter_name}}, {{class_name}}::{{setter_name}}));
 {{/is_used}}
 {{/is_class_attribute}}
 {{#is_list_attribute}}
 {{#is_used}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{label}}ToString, {{class_name}}::{{setter_name}}, null));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", true, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{getter_name}}, {{class_name}}::{{setter_name}}));
 {{/is_used}}
 {{^is_used}}
-            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", false, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{label}}ToString, {{class_name}}::{{setter_name}}, null));
+            map.put("{{label}}", new AttrDetails("{{class_name}}.{{label}}", false, "{{attribute_namespace}}", profiles, false, false, {{class_name}}::{{getter_name}}, {{class_name}}::{{setter_name}}));
 {{/is_used}}
 {{/is_list_attribute}}
         }

--- a/cimgen/languages/java/templates/java_class.mustache
+++ b/cimgen/languages/java/templates/java_class.mustache
@@ -41,7 +41,7 @@ public class {{class_name}} extends {{subclass_of}} {
 
     /**
 {{#comment}}
-     * {{comment}}
+     * {{{comment}}}
 {{/comment}}
 {{^is_used}}
      *

--- a/cimgen/languages/java/templates/java_class.mustache
+++ b/cimgen/languages/java/templates/java_class.mustache
@@ -25,10 +25,17 @@ public class {{class_name}} extends {{subclass_of}} {
     private static final Logging LOG = Logging.getLogger({{class_name}}.class);
 
     /**
-     * Default constructor.
+     * Constructor.
      */
-    public {{class_name}}() {
-        setCimType("{{class_name}}");
+    public {{class_name}}(String rdfid) {
+        super("{{class_name}}", rdfid);
+    }
+
+    /**
+     * Constructor for subclasses.
+     */
+    protected {{class_name}}(String cimType, String rdfid) {
+        super(cimType, rdfid);
     }
 {{#attributes}}
 
@@ -423,7 +430,7 @@ public class {{class_name}} extends {{subclass_of}} {
         }
 {{/attributes}}
         CLASS_ATTR_DETAILS_MAP = map;
-        ATTR_DETAILS_MAP = Collections.unmodifiableMap(new {{class_name}}().allAttrDetailsMap());
+        ATTR_DETAILS_MAP = Collections.unmodifiableMap(new {{class_name}}(null).allAttrDetailsMap());
         ATTR_NAMES_LIST = new ArrayList<>(ATTR_DETAILS_MAP.keySet());
     }
 

--- a/cimgen/languages/java/templates/java_classlist.mustache
+++ b/cimgen/languages/java/templates/java_classlist.mustache
@@ -7,7 +7,7 @@ package cim4j;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 public final class CimClassMap {
 
@@ -25,34 +25,36 @@ public final class CimClassMap {
      * Creates a new CIM object.
      *
      * @param className The class name of the new CIM object.
+     * @param rdfid     The RDF ID of the CIM object read from rdf:ID or rdf:about.
      * @return          The new CIM object.
      */
-    public static BaseClass createCimObject(String className) {
+    public static BaseClass createCimObject(String className, String rdfid) {
         var createFunction = CREATE_MAP.get(className);
-        return createFunction.get();
+        return createFunction.apply(rdfid);
     }
 
     /**
      * Creates a new CIM object (as object of the correct class).
      *
      * @param clazz The class of the new CIM object.
+     * @param rdfid The RDF ID of the CIM object read from rdf:ID or rdf:about.
      * @return      The new CIM object.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends BaseClass> T createCimObject(Class<T> clazz) {
+    public static <T extends BaseClass> T createCimObject(Class<T> clazz, String rdfid) {
         var className = clazz.getSimpleName();
-        return (T) createCimObject(className);
+        return (T) createCimObject(className, rdfid);
     }
 
     /**
-     * Map of CIM class name to supplier function which creates a new CIM object.
+     * Map of CIM class name to constructor function which creates a new CIM object.
      */
-    private static final Map<String, Supplier<BaseClass>> CREATE_MAP;
+    private static final Map<String, Function<String, BaseClass>> CREATE_MAP;
     static {
-        var map = new LinkedHashMap<String, Supplier<BaseClass>>();
+        var map = new LinkedHashMap<String, Function<String, BaseClass>>();
 
 {{#classes}}
-        map.put("{{.}}", () -> new {{.}}());
+        map.put("{{.}}", rdfid -> new {{.}}(rdfid));
 {{/classes}}
 
         CREATE_MAP = Collections.unmodifiableMap(map);

--- a/cimgen/languages/java/templates/java_enum.mustache
+++ b/cimgen/languages/java/templates/java_enum.mustache
@@ -17,7 +17,7 @@ public enum {{class_name}} {
 {{#enum_instances}}
 {{#comment}}
     /**
-     * {{comment}}
+     * {{{comment}}}
      */
 {{/comment}}
     _{{label}}("{{label}}"),

--- a/cimgen/languages/java/utils/RdfParser.java
+++ b/cimgen/languages/java/utils/RdfParser.java
@@ -12,11 +12,14 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import cim4j.CimConstants;
+import cim4j.Logging;
 
 /**
  * Read RDF files into a map of rdfid to CIM object.
  */
 public final class RdfParser {
+
+    private static final Logging LOG = Logging.getLogger(RdfParser.class);
 
     private static final String RDF = CimConstants.NAMESPACES_MAP.get("rdf");
     private static final String MD = CimConstants.NAMESPACES_MAP.get("md"); // ModelDescription
@@ -58,7 +61,9 @@ public final class RdfParser {
                 }
             }
         } catch (Exception ex) {
-            throw new RuntimeException("Error while parsing RDF/XML data", ex);
+            String txt = "Error while parsing RDF/XML data";
+            LOG.error(txt, ex);
+            throw new RuntimeException(txt, ex);
         }
     }
 

--- a/cimgen/languages/java/utils/RdfReader.java
+++ b/cimgen/languages/java/utils/RdfReader.java
@@ -3,11 +3,9 @@ package cim4j.utils;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import cim4j.BaseClass;
 import cim4j.CimClassMap;
@@ -21,7 +19,6 @@ public class RdfReader {
     private static final Logging LOG = Logging.getLogger(RdfReader.class);
 
     private final Map<String, BaseClass> model = new LinkedHashMap<>();
-    private final HandleSetLater handleSetLater = new HandleSetLater();
 
     /**
      * Read the CIM data from a list of RDF files.
@@ -31,7 +28,6 @@ public class RdfReader {
      */
     public Map<String, BaseClass> read(List<String> pathList) {
         model.clear();
-        handleSetLater.clear();
         for (String path : pathList) {
             int count = model.size();
             long memory = getUsedMemory();
@@ -46,7 +42,20 @@ public class RdfReader {
             LOG.info(String.format("Read %d CIM objects from %s using %d MByte (%d)", model.size() - count,
                     path, memory / (1024 * 1024), memory));
         }
-        logRemainingResources();
+        for (String path : pathList) {
+            int count = model.size();
+            long memory = getUsedMemory();
+            try (var stream = new FileInputStream(path)) {
+                RdfParser.parse(stream, this::addAttributes);
+            } catch (Exception ex) {
+                String txt = "Error while adding attributes read from rdf file: " + path;
+                LOG.error(txt, ex);
+                throw new RuntimeException(txt, ex);
+            }
+            memory = getUsedMemory() - memory;
+            LOG.info(String.format("Fill %d CIM objects from %s using %d MByte (%d)", model.size() - count,
+                    path, memory / (1024 * 1024), memory));
+        }
         return model;
     }
 
@@ -58,7 +67,6 @@ public class RdfReader {
      */
     public Map<String, BaseClass> readFromStrings(List<String> xmlList) {
         model.clear();
-        handleSetLater.clear();
         for (String xml : xmlList) {
             int count = model.size();
             long memory = getUsedMemory();
@@ -73,7 +81,20 @@ public class RdfReader {
             LOG.info(String.format("Read %d CIM objects using %d MByte (%d)", model.size() - count,
                     memory / (1024 * 1024), memory));
         }
-        logRemainingResources();
+        for (String xml : xmlList) {
+            int count = model.size();
+            long memory = getUsedMemory();
+            try (var stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+                RdfParser.parse(stream, this::addAttributes);
+            } catch (Exception ex) {
+                String txt = "Error while adding attributes";
+                LOG.error(txt, ex);
+                throw new RuntimeException(txt, ex);
+            }
+            memory = getUsedMemory() - memory;
+            LOG.info(String.format("Fill %d CIM objects using %d MByte (%d)", model.size() - count,
+                    memory / (1024 * 1024), memory));
+        }
         return model;
     }
 
@@ -86,23 +107,18 @@ public class RdfReader {
                     object = createNewObject(className, element.id);
                     model.put(element.id, object);
                 } else if (!object.getCimType().equals(className)) {
-                    BaseClass newObject = retypeObject(object, className, element.id);
-                    if (newObject != null) {
-                        object = newObject;
-                        model.put(element.id, object);
+                    BaseClass newObject = createNewObject(className, element.id);
+                    var oldType = object.getClass();
+                    var newType = newObject.getClass();
+                    if (oldType.isAssignableFrom(newType)) {
+                        LOG.debug(String.format("Retyping object with rdf:ID: %s from type: %s to type: %s",
+                                element.id, object.getCimType(), className));
+                        model.put(element.id, newObject);
                     } else {
                         LOG.debug(String.format("Found %s (instead of %s) with rdf:ID: %s in map", object.getCimType(),
                                 className, element.id));
                     }
                 }
-
-                // Set attributes of new object
-                for (RdfParser.Attribute attribute : element.attributes) {
-                    setAttribute(object, attribute);
-                }
-
-                // Set object as link in other objects previously found
-                handleSetLater.execute(object);
             } else {
                 LOG.warn(String.format("Unknown CIM class: %s (rdf:ID: %s)", className, element.id));
             }
@@ -111,50 +127,21 @@ public class RdfReader {
         }
     }
 
+    private void addAttributes(RdfParser.Element element) {
+        if (element.id != null && model.containsKey(element.id)) {
+            BaseClass object = model.get(element.id);
+
+            // Set attributes of new object
+            for (RdfParser.Attribute attribute : element.attributes) {
+                setAttribute(object, attribute);
+            }
+        }
+    }
+
     private BaseClass createNewObject(String className, String rdfid) {
         BaseClass object = CimClassMap.createCimObject(className, rdfid);
         LOG.debug(String.format("Created object of type: %s with rdf:ID: %s", className, rdfid));
         return object;
-    }
-
-    private BaseClass retypeObject(BaseClass oldObject, String className, String rdfid) {
-        BaseClass newObject = createNewObject(className, rdfid);
-        var oldType = oldObject.getClass();
-        var newType = newObject.getClass();
-        if (oldType.isAssignableFrom(newType)) {
-            LOG.debug(String.format("Retyping object with rdf:ID: %s from type: %s to type: %s", rdfid,
-                    oldObject.getCimType(), className));
-
-            // Copy attributes from old object to the new object
-            for (String attrName : oldObject.getAttributeNames()) {
-                Object attr = oldObject.getAttribute(attrName);
-                if (attr != null) {
-                    if (oldObject.isPrimitiveAttribute(attrName) || oldObject.isEnumAttribute(attrName)) {
-                        newObject.setAttribute(attrName, attr);
-                    } else if (attr instanceof BaseClass) {
-                        newObject.setAttribute(attrName, attr);
-                        removeObjectInAttributeObject((BaseClass) attr, oldObject);
-                    } else if (attr instanceof Set<?>) {
-                        for (var attrObject : ((Set<?>) attr)) {
-                            newObject.setAttribute(attrName, attrObject);
-                        }
-                    }
-                }
-            }
-
-            handleSetLater.replace(oldObject, newObject);
-            return newObject;
-        }
-        return null;
-    }
-
-    private void removeObjectInAttributeObject(BaseClass attrObject, BaseClass oldObject) {
-        for (String attrName : attrObject.getAttributeNames()) {
-            Object attr = attrObject.getAttribute(attrName);
-            if (attr instanceof Set<?> && ((Set<?>) attr).contains(oldObject)) {
-                ((Set<?>) attr).remove(oldObject);
-            }
-        }
     }
 
     private void setAttribute(BaseClass object, RdfParser.Attribute attribute) {
@@ -167,25 +154,17 @@ public class RdfReader {
                 LOG.error(String.format("Unknown attribute %s with resource %s", attribute.name.getLocalPart(),
                         attribute.resource));
             } else if (!object.isEnumAttribute(attributeName)) {
-                boolean setLater = false;
                 if (model.containsKey(attribute.resource)) {
                     // Set class or list attribute as link to an already existing object
                     BaseClass attributeObject = model.get(attribute.resource);
                     try {
                         object.setAttribute(attributeName, attributeObject);
-                        // Prevent to set the class attribute later
-                        if (!(object.getAttribute(attributeName) instanceof Set<?>)) {
-                            handleSetLater.remove(object, attributeName);
-                        }
                     } catch (IllegalArgumentException ex) {
-                        setLater = true;
+                        LOG.error(String.format("Cannot set attribute %s with attribute object: %s", attributeName,
+                                attributeObject), ex);
                     }
                 } else {
-                    setLater = true;
-                }
-                if (setLater) {
-                    // Set class or list attribute later
-                    handleSetLater.add(object, attributeName, attribute.resource);
+                    LOG.error(String.format("Cannot find object with rdf:ID: %s", attribute.resource));
                 }
             } else {
                 // Set enum attributes
@@ -197,119 +176,8 @@ public class RdfReader {
         }
     }
 
-    private void logRemainingResources() {
-        for (var resource : handleSetLater.getResources()) {
-            BaseClass object = model.get(resource);
-            if (object == null) {
-                LOG.error(String.format("Cannot find object with rdf:ID: %s", resource));
-            } else {
-                LOG.error(String.format("Cannot set attributes with attribute object: %s", object));
-            }
-        }
-    }
-
     private long getUsedMemory() {
         Runtime.getRuntime().gc();
         return Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-    }
-
-    private static class HandleSetLater {
-        private final Map<String, Map<String, List<BaseClass>>> resourceNameObjectMap = new LinkedHashMap<>();
-        private final Map<BaseClass, Map<String, List<String>>> objectNameResourceMap = new LinkedHashMap<>();
-
-        public void clear() {
-            resourceNameObjectMap.clear();
-            objectNameResourceMap.clear();
-        }
-
-        public void add(BaseClass object, String attrName, String resource) {
-            // If its a class attribute remove previously set resources
-            if (!(object.getAttribute(attrName) instanceof Set<?>)) {
-                remove(object, attrName);
-            }
-
-            var nameObjectMap = resourceNameObjectMap.computeIfAbsent(resource, k -> new LinkedHashMap<>());
-            nameObjectMap.computeIfAbsent(attrName, k -> new ArrayList<>()).add(object);
-
-            var nameResourceMap = objectNameResourceMap.computeIfAbsent(object, k -> new LinkedHashMap<>());
-            nameResourceMap.computeIfAbsent(attrName, k -> new ArrayList<>()).add(resource);
-        }
-
-        public void execute(BaseClass object) {
-            var resource = object.getRdfid();
-            if (resourceNameObjectMap.containsKey(resource)) {
-                var removeNameObjectMap = new LinkedHashMap<String, List<BaseClass>>();
-                for (var nameAndObjects : resourceNameObjectMap.get(resource).entrySet()) {
-                    var attrName = nameAndObjects.getKey();
-                    for (var otherObject : nameAndObjects.getValue()) {
-                        boolean success = true;
-                        try {
-                            otherObject.setAttribute(attrName, object);
-                        } catch (IllegalArgumentException ex) {
-                            success = false;
-                        }
-                        if (success) {
-                            removeNameObjectMap.computeIfAbsent(attrName, k -> new ArrayList<>()).add(otherObject);
-                        }
-                    }
-                }
-                for (var attrName : removeNameObjectMap.keySet()) {
-                    for (var otherObject : removeNameObjectMap.get(attrName)) {
-                        remove(otherObject, attrName, resource);
-                    }
-                }
-            }
-        }
-
-        public void remove(BaseClass object, String attrName) {
-            var nameResourceMap = objectNameResourceMap.get(object);
-            if (nameResourceMap != null && nameResourceMap.containsKey(attrName)) {
-                var removeResources = new ArrayList<>(nameResourceMap.get(attrName));
-                for (var resource : removeResources) {
-                    remove(object, attrName, resource);
-                }
-            }
-        }
-
-        public void replace(BaseClass oldObject, BaseClass newObject) {
-            var nameResourceMap = objectNameResourceMap.get(oldObject);
-            if (nameResourceMap != null) {
-                for (var attrName : nameResourceMap.keySet()) {
-                    for (var resource : nameResourceMap.get(attrName)) {
-                        var objects = resourceNameObjectMap.get(resource).get(attrName);
-                        objects.set(objects.indexOf(oldObject), newObject);
-                    }
-                }
-                objectNameResourceMap.remove(oldObject);
-                objectNameResourceMap.put(newObject, nameResourceMap);
-            }
-        }
-
-        public Set<String> getResources() {
-            return resourceNameObjectMap.keySet();
-        }
-
-        private void remove(BaseClass object, String attrName, String resource) {
-            var nameObjectMap = resourceNameObjectMap.get(resource);
-            if (nameObjectMap != null && nameObjectMap.containsKey(attrName)) {
-                nameObjectMap.get(attrName).remove(object);
-                if (nameObjectMap.get(attrName).isEmpty()) {
-                    nameObjectMap.remove(attrName);
-                }
-                if (nameObjectMap.isEmpty()) {
-                    resourceNameObjectMap.remove(resource);
-                }
-            }
-            var nameResourceMap = objectNameResourceMap.get(object);
-            if (nameResourceMap != null && nameResourceMap.containsKey(attrName)) {
-                nameResourceMap.get(attrName).remove(resource);
-                if (nameResourceMap.get(attrName).isEmpty()) {
-                    nameResourceMap.remove(attrName);
-                }
-                if (nameResourceMap.isEmpty()) {
-                    objectNameResourceMap.remove(object);
-                }
-            }
-        }
     }
 }

--- a/cimgen/languages/java/utils/RdfReader.java
+++ b/cimgen/languages/java/utils/RdfReader.java
@@ -153,7 +153,10 @@ public class RdfReader {
             attributeName = attributeName.substring(attributeName.lastIndexOf('.') + 1);
         }
         if (attribute.resource != null) {
-            if (!object.isEnumAttribute(attributeName)) {
+            if (!object.getAttributeNames().contains(attributeName)) {
+                LOG.error(String.format("Unknown attribute %s with resource %s", attribute.name.getLocalPart(),
+                        attribute.resource));
+            } else if (!object.isEnumAttribute(attributeName)) {
                 if (model.containsKey(attribute.resource)) {
                     // Set class attribute as link to an already existng object
                     BaseClass attributeObject = model.get(attribute.resource);
@@ -186,7 +189,7 @@ public class RdfReader {
                     object.setAttribute(setAttribute.name, attributeObject);
                 }
             } else {
-                LOG.warn(String.format("Cannot find object with rdf:ID: %s", resource));
+                LOG.error(String.format("Cannot find object with rdf:ID: %s", resource));
             }
         }
     }

--- a/cimgen/languages/java/utils/RdfReader.java
+++ b/cimgen/languages/java/utils/RdfReader.java
@@ -89,8 +89,7 @@ public class RdfReader {
     }
 
     private BaseClass createNewObject(String className, String rdfid) {
-        BaseClass object = CimClassMap.createCimObject(className);
-        object.setRdfid(rdfid);
+        BaseClass object = CimClassMap.createCimObject(className, rdfid);
         LOG.debug(String.format("Created object of type: %s with rdf:ID: %s", className, rdfid));
         return object;
     }

--- a/cimgen/languages/java/utils/RdfWriter.java
+++ b/cimgen/languages/java/utils/RdfWriter.java
@@ -283,7 +283,9 @@ public class RdfWriter {
             LOG.info(String.format("Written %d of %d CIM objects to RDF", count, cimData.size()));
             return count != 0;
         } catch (Exception ex) {
-            throw new RuntimeException("Error while writing RDF/XML data", ex);
+            String txt = "Error while writing RDF/XML data";
+            LOG.error(txt, ex);
+            throw new RuntimeException(txt, ex);
         }
     }
 

--- a/cimgen/languages/java/utils/RdfWriter.java
+++ b/cimgen/languages/java/utils/RdfWriter.java
@@ -212,9 +212,9 @@ public class RdfWriter {
                     var attrNames = cimObj.getAttributeNames();
                     boolean noAttrFound = true;
                     for (String attrName : attrNames) {
-                        Object attr = cimObj.getAttribute(attrName);
-                        if (attr != null && cimObj.isUsedAttribute(attrName) && (profile == null
-                                || getAttributeProfile(cimObj, attrName, classProfile) == profile)) {
+                        if (cimObj.isUsedAttribute(attrName) && cimObj.getAttribute(attrName) != null
+                                && (profile == null
+                                        || getAttributeProfile(cimObj, attrName, classProfile) == profile)) {
                             noAttrFound = false;
                             break;
                         }
@@ -232,38 +232,40 @@ public class RdfWriter {
                     }
 
                     for (String attrName : attrNames) {
-                        var namespaceUrl = cimObj.getAttributeNamespaceUrl(attrName);
-                        String attrFullName = cimObj.getAttributeFullName(attrName);
-                        Object attr = cimObj.getAttribute(attrName);
-                        if (attr != null && cimObj.isUsedAttribute(attrName) && (profile == null
+                        if (cimObj.isUsedAttribute(attrName) && (profile == null
                                 || getAttributeProfile(cimObj, attrName, classProfile) == profile)) {
-                            if (cimObj.isPrimitiveAttribute(attrName)) {
-                                writer.writeCharacters("\n    ");
-                                writer.writeStartElement(namespaceUrl, attrFullName);
-                                writer.writeCharacters(attr.toString());
-                                writer.writeEndElement();
-                            } else if (cimObj.isEnumAttribute(attrName)) {
-                                String resource = attr.toString();
-                                if (!resource.contains("#")) {
-                                    resource = "#" + resource;
-                                } else if (resource.indexOf("#") != 0) {
-                                    String[] parts = resource.split("#");
-                                    resource = namespaceUrl + parts[1];
-                                }
-                                writer.writeCharacters("\n    ");
-                                writer.writeEmptyElement(namespaceUrl, attrFullName);
-                                writer.writeAttribute(RDF, "resource", resource);
-                            } else if (attr instanceof BaseClass) {
-                                String resource = "#" + ((BaseClass) attr).getRdfid();
-                                writer.writeCharacters("\n    ");
-                                writer.writeEmptyElement(namespaceUrl, attrFullName);
-                                writer.writeAttribute(RDF, "resource", resource);
-                            } else if (attr instanceof Set<?>) {
-                                for (var attrObject : ((Set<?>) attr)) {
-                                    String resource = "#" + ((BaseClass) attrObject).getRdfid();
+                            Object attr = cimObj.getAttribute(attrName);
+                            if (attr != null) {
+                                var namespaceUrl = cimObj.getAttributeNamespaceUrl(attrName);
+                                String attrFullName = cimObj.getAttributeFullName(attrName);
+                                if (cimObj.isPrimitiveAttribute(attrName)) {
+                                    writer.writeCharacters("\n    ");
+                                    writer.writeStartElement(namespaceUrl, attrFullName);
+                                    writer.writeCharacters(attr.toString());
+                                    writer.writeEndElement();
+                                } else if (cimObj.isEnumAttribute(attrName)) {
+                                    String resource = attr.toString();
+                                    if (!resource.contains("#")) {
+                                        resource = "#" + resource;
+                                    } else if (resource.indexOf("#") != 0) {
+                                        String[] parts = resource.split("#");
+                                        resource = namespaceUrl + parts[1];
+                                    }
                                     writer.writeCharacters("\n    ");
                                     writer.writeEmptyElement(namespaceUrl, attrFullName);
                                     writer.writeAttribute(RDF, "resource", resource);
+                                } else if (attr instanceof BaseClass) {
+                                    String resource = "#" + ((BaseClass) attr).getRdfid();
+                                    writer.writeCharacters("\n    ");
+                                    writer.writeEmptyElement(namespaceUrl, attrFullName);
+                                    writer.writeAttribute(RDF, "resource", resource);
+                                } else if (attr instanceof Set<?>) {
+                                    for (var attrObject : ((Set<?>) attr)) {
+                                        String resource = "#" + ((BaseClass) attrObject).getRdfid();
+                                        writer.writeCharacters("\n    ");
+                                        writer.writeEmptyElement(namespaceUrl, attrFullName);
+                                        writer.writeAttribute(RDF, "resource", resource);
+                                    }
                                 }
                             }
                         }
@@ -397,8 +399,7 @@ public class RdfWriter {
             urls.add(cimObj.getClassNamespaceUrl());
             var attrNames = cimObj.getAttributeNames();
             for (String attrName : attrNames) {
-                Object attr = cimObj.getAttribute(attrName);
-                if (attr != null && cimObj.isUsedAttribute(attrName)) {
+                if (cimObj.isUsedAttribute(attrName) && cimObj.getAttribute(attrName) != null) {
                     urls.add(cimObj.getAttributeNamespaceUrl(attrName));
                 }
             }

--- a/documentation/CIMgenOverview.md
+++ b/documentation/CIMgenOverview.md
@@ -2,23 +2,23 @@
 
 | Project                 | cpp      | java     | javascript | modernpython | python    |
 |:------------------------|:--------:|:--------:|:----------:|:------------:|:---------:|
-| sogno-platform          | [libcimpp](https://github.com/sogno-platform/libcimpp) | [c4j](https://github.com/sogno-platform/cim4j) | [pintura](https://github.com/sogno-platform/pintura) | - | [cimpy](https://github.com/sogno-platform/cimpy) |
+| sogno-platform          | [libcimpp](https://github.com/sogno-platform/libcimpp) | [cim4j](https://github.com/sogno-platform/cim4j) | [pintura](https://github.com/sogno-platform/pintura) | - | [cimpy](https://github.com/sogno-platform/cimpy) |
 | Other github            |          |          |            | [alliander-opensource/pycgmes](https://github.com/alliander-opensource/pycgmes) | |
-| Release packages        | deb, rpm | -        | docker     | pip          | pip       |
-| Current release         | [GitHub](https://github.com/sogno-platform/libcimpp/releases/latest) | - | [Docker Hub](https://hub.docker.com/r/sogno/pintura) | [PyPI](https://pypi.org/project/pycgmes) | [PyPI](https://pypi.org/project/cimpy) |
+| Release packages        | deb, rpm | jar      | docker     | pip          | pip       |
+| Current release         | [GitHub](https://github.com/sogno-platform/libcimpp/releases/latest) | [GitHub](https://github.com/sogno-platform/cim4j/releases/latest) | [Docker Hub](https://hub.docker.com/r/sogno/pintura) | [PyPI](https://pypi.org/project/pycgmes) | [PyPI](https://pypi.org/project/cimpy) |
 | **Workflows**           |          |          |            |              |           |
 | CIMgen upgrade workflow | -        | -        | -          | -            | -         |
-| Check workflow          | -                                                                                       | - | -                                                                                   | [build](https://github.com/alliander-opensource/pycgmes/actions/workflows/build.yaml)   | [pre-commit](https://github.com/sogno-platform/cimpy/actions/workflows/pre-commit.yaml) |
-| Build workflow          | [build-src](https://github.com/sogno-platform/libcimpp/actions/workflows/build-src.yml) | - | -                                                                                   | [build](https://github.com/alliander-opensource/pycgmes/actions/workflows/build.yaml)   | [test](https://github.com/sogno-platform/cimpy/actions/workflows/test.yaml)             |
-| Test workflow           | -                                                                                       | - | -                                                                                   | [build](https://github.com/alliander-opensource/pycgmes/actions/workflows/build.yaml)   | [test](https://github.com/sogno-platform/cimpy/actions/workflows/test.yaml)             |
-| Docs workflow           | [build-doc](https://github.com/sogno-platform/libcimpp/actions/workflows/build-doc.yml) | - | [pages](https://github.com/sogno-platform/pintura/actions/workflows/pages.yaml)     | -                                                                                       | [docs](https://github.com/sogno-platform/cimpy/actions/workflows/docs.yaml)             |
-| Release workflow        | [release](https://github.com/sogno-platform/libcimpp/actions/workflows/release.yml)     | - | [release](https://github.com/sogno-platform/pintura/actions/workflows/release.yaml) | [deploy](https://github.com/alliander-opensource/pycgmes/actions/workflows/deploy.yaml) | - |
+| Check workflow          | -        | -        | -          | [build](https://github.com/alliander-opensource/pycgmes/actions/workflows/build.yaml) | [pre-commit](https://github.com/sogno-platform/cimpy/actions/workflows/pre-commit.yaml) |
+| Build workflow          | [build-src](https://github.com/sogno-platform/libcimpp/actions/workflows/build-src.yml) | [build](https://github.com/sogno-platform/cim4j/blob/main/.github/workflows/build.yml) | - | [build](https://github.com/alliander-opensource/pycgmes/actions/workflows/build.yaml) | [test](https://github.com/sogno-platform/cimpy/actions/workflows/test.yaml) |
+| Test workflow           | -        | -        | -          | [build](https://github.com/alliander-opensource/pycgmes/actions/workflows/build.yaml) | [test](https://github.com/sogno-platform/cimpy/actions/workflows/test.yaml) |
+| Docs workflow           | [build-doc](https://github.com/sogno-platform/libcimpp/actions/workflows/build-doc.yml) | - | [pages](https://github.com/sogno-platform/pintura/actions/workflows/pages.yaml) | - | [docs](https://github.com/sogno-platform/cimpy/actions/workflows/docs.yaml) |
+| Release workflow        | [release](https://github.com/sogno-platform/libcimpp/actions/workflows/release.yml) | [release](https://github.com/sogno-platform/cim4j/blob/main/.github/workflows/release.yml) | [release](https://github.com/sogno-platform/pintura/actions/workflows/release.yaml) | [deploy](https://github.com/alliander-opensource/pycgmes/actions/workflows/deploy.yaml) | - |
 | **CIM features**        |          |          |            |              |           |
-| Multi version           | x        | -        | -          | -            | -         |
+| Multi version           | x        | x        | -          | -            | -         |
 | CGMES_2.4.13_18DEC2013  | (source) | -        | -          | -            | -         |
 | CGMES_2.4.15_16FEB2016  | (source) | -        | -          | -            | -         |
-| CGMES_2.4.15_27JAN2020  | x        | (source) | x          | -            | x         |
-| CGMES_3.0.0             | x        | -        | -          | x            | -         |
-| Profiles                | x        | -        | x          | x            | -         |
-| Custom profiles         | -        | -        | -          | x            | -         |
-| Custom namespaces       | -        | -        | -          | x            | -         |
+| CGMES_2.4.15_27JAN2020  | x        | x        | x          | -            | x         |
+| CGMES_3.0.0             | x        | x        | -          | x            | -         |
+| Profiles                | x        | x        | x          | x            | -         |
+| Custom profiles         | -        | x        | -          | x            | -         |
+| Custom namespaces       | -        | x        | -          | x            | -         |


### PR DESCRIPTION
- Change getter and setter to static functions
- Set cimType and rdfid in BaseClass constructor (fixing this-escape warnings with Java >= 21)
- Remove setter for cimType and rdfid (they are fixed now after creation of a CIM object)
- Fix parsing objects with changing types (e.g. first as Equipment, than as PowerTransformer)
- Add method toString to BaseClass
- Improve logging of unknown attributes in java reader
- Fix parsing objects with overriding attributes
- Add option --log-level to java main program
- Fix collision of label and class_name (e.g. AvailabilitySchedule in profile AvailabilitySchedule)
- Update java in documentation/CIMgenOverview.md
- Add logging of used memory in java reader
- Optimize java writer: iterate over used attributes only
- Fix attribute comments
- Fix exception caused by wrong attribute type
- Improve java reader with class HandleSetLater
- Improve java reader using robust two-phase algorithm: 1. create objects, 2. add attributes (avoiding any complicated set-later algorithms)
- Set log4jEnabled = false in Logging.java
