### PR TITLE
Fix custom namespace for cpp

### DIFF
--- a/cimgen/languages/cpp/static/BaseClass.cpp
+++ b/cimgen/languages/cpp/static/BaseClass.cpp
@@ -4,8 +4,15 @@ using namespace CIMPP;
 
 BaseClass::~BaseClass() {}
 
-std::list<CGMESProfile> BaseClass::getPossibleProfilesForClass() const { return {}; }
-std::map<std::string, std::list<CGMESProfile>> BaseClass::getPossibleProfilesForAttributes() const { return {}; }
+const std::list<std::string>& BaseClass::getAttributeNames() const { return CimClassDetails::UnknownAttributes; };
+
+const std::string& BaseClass::getClassNamespaceUrl() const { return CimClassDetails::UnknownNamespace; }
+const std::string& BaseClass::getAttributeNamespaceUrl(const std::string& /*attrName*/) const { return CimClassDetails::UnknownNamespace; }
+
+const std::list<CGMESProfile>& BaseClass::getPossibleProfiles() const { return CimClassDetails::UnknownProfiles; }
+const CGMESProfile& BaseClass::getRecommendedProfile() const { return UnknownProfile; }
+const std::list<CGMESProfile>& BaseClass::getPossibleAttributeProfiles(const std::string& /*attrName*/) const { return CimClassDetails::UnknownProfiles; }
+const std::list<CGMESProfile>& BaseClass::getPossibleProfilesIncludingAttributes() const { return CimClassDetails::UnknownProfiles; }
 
 const char BaseClass::debugName[] = "BaseClass";
 const char* BaseClass::debugString() const
@@ -23,4 +30,9 @@ void BaseClass::addEnumGetFnsToMap(std::map<std::string, get_function>& get_map)
 const BaseClassDefiner BaseClass::declare()
 {
 	return BaseClassDefiner(BaseClass::addConstructToMap, BaseClass::addPrimitiveAssignFnsToMap, BaseClass::addClassAssignFnsToMap, BaseClass::debugName);
+}
+
+std::map<std::string, AttrDetails> BaseClass::allAttrDetailsMap() const
+{
+	return {};
 }

--- a/cimgen/languages/cpp/static/BaseClass.hpp
+++ b/cimgen/languages/cpp/static/BaseClass.hpp
@@ -12,6 +12,7 @@
 
 #include "BaseClassDefiner.hpp"
 #include "CGMESProfile.hpp"
+#include "CimClassDetails.hpp"
 
 class BaseClass;
 typedef bool (*class_get_function)(const BaseClass*, std::list<const BaseClass*>&);
@@ -29,8 +30,15 @@ public:
 	static const char debugName[];
 	virtual const char* debugString() const;
 
-	virtual std::list<CGMESProfile> getPossibleProfilesForClass() const;
-	virtual std::map<std::string, std::list<CGMESProfile>> getPossibleProfilesForAttributes() const;
+	virtual const std::list<std::string>& getAttributeNames() const;
+
+	virtual const std::string& getClassNamespaceUrl() const;
+	virtual const std::string& getAttributeNamespaceUrl(const std::string& attrName) const;
+
+	virtual const std::list<CGMESProfile>& getPossibleProfiles() const;
+	virtual const CGMESProfile& getRecommendedProfile() const;
+	virtual const std::list<CGMESProfile>& getPossibleAttributeProfiles(const std::string& attrName) const;
+	virtual const std::list<CGMESProfile>& getPossibleProfilesIncludingAttributes() const;
 
 	static void addConstructToMap(std::unordered_map<std::string, BaseClass* (*)()>& factory_map);
 	static void addPrimitiveAssignFnsToMap(std::unordered_map<std::string, assign_function>& assign_map);
@@ -39,5 +47,9 @@ public:
 	virtual void addClassGetFnsToMap(std::map<std::string, class_get_function>& get_map) const;
 	virtual void addEnumGetFnsToMap(std::map<std::string, get_function>& get_map) const;
 	static const CIMPP::BaseClassDefiner declare();
+
+protected:
+	friend class CimClassDetails;
+	virtual std::map<std::string, AttrDetails> allAttrDetailsMap() const;
 };
 #endif // BASECLASS_HPP

--- a/cimgen/languages/cpp/static/BaseClass.hpp
+++ b/cimgen/languages/cpp/static/BaseClass.hpp
@@ -46,6 +46,8 @@ public:
 	virtual void addPrimitiveGetFnsToMap(std::map<std::string, get_function>& get_map) const;
 	virtual void addClassGetFnsToMap(std::map<std::string, class_get_function>& get_map) const;
 	virtual void addEnumGetFnsToMap(std::map<std::string, get_function>& get_map) const;
+
+	virtual bool isAssignableFrom(BaseClass* otherObject) const { return false; }
 	static const CIMPP::BaseClassDefiner declare();
 
 protected:

--- a/cimgen/languages/cpp/static/CimClassDetails.cpp
+++ b/cimgen/languages/cpp/static/CimClassDetails.cpp
@@ -1,0 +1,63 @@
+#include "CimClassDetails.hpp"
+
+#include "BaseClass.hpp"
+
+CimClassDetails::CimClassDetails(
+	const BaseClass& obj,
+	std::string classNamespace,
+	std::list<CGMESProfile> possibleProfiles,
+	CGMESProfile recommendedProfile)
+:
+	ClassNamespace(classNamespace),
+	AttrDetailsMap(obj.allAttrDetailsMap()),
+	AttrNamesList(constructAttrNamesList(AttrDetailsMap)),
+	PossibleProfiles(possibleProfiles),
+	RecommendedProfile(recommendedProfile),
+	PossibleProfilesIncludingAttributes(constructPossibleProfilesIncludingAttributes(PossibleProfiles, AttrDetailsMap))
+{
+}
+
+const std::string& CimClassDetails::getAttributeNamespaceUrl(const std::string& attrName) const
+{
+	if (AttrDetailsMap.find(attrName) != AttrDetailsMap.end())
+	{
+		return AttrDetailsMap.at(attrName).nameSpace;
+	}
+	return UnknownNamespace;
+}
+
+const std::list<CGMESProfile>& CimClassDetails::getPossibleAttributeProfiles(const std::string& attrName) const
+{
+	if (AttrDetailsMap.find(attrName) != AttrDetailsMap.end())
+	{
+		return AttrDetailsMap.at(attrName).profiles;
+	}
+	return UnknownProfiles;
+}
+
+std::list<std::string> CimClassDetails::constructAttrNamesList(const std::map<std::string, AttrDetails>& attrDetailsMap)
+{
+	std::list<std::string> list;
+	for (const auto& nameAndDetails : attrDetailsMap)
+	{
+		list.push_back(nameAndDetails.first);
+	}
+	return list;
+}
+
+std::list<CGMESProfile> CimClassDetails::constructPossibleProfilesIncludingAttributes(
+	const std::list<CGMESProfile>& possibleProfiles,
+	const std::map<std::string, AttrDetails>& attrDetailsMap)
+{
+	auto profiles = possibleProfiles;
+	for (const auto& nameAndDetails : attrDetailsMap)
+	{
+		const auto& attrProfiles = nameAndDetails.second.profiles;
+		profiles.insert(profiles.end(), attrProfiles.begin(), attrProfiles.end());
+	}
+	return profiles;
+}
+
+const std::list<std::string> CimClassDetails::UnknownAttributes;
+const std::string CimClassDetails::UnknownNamespace;
+const std::list<CGMESProfile> CimClassDetails::UnknownProfiles;

--- a/cimgen/languages/cpp/static/CimClassDetails.hpp
+++ b/cimgen/languages/cpp/static/CimClassDetails.hpp
@@ -1,0 +1,51 @@
+#ifndef CIMCLASSDETAILS_HPP
+#define CIMCLASSDETAILS_HPP
+
+#include <list>
+#include <map>
+#include <string>
+
+#include "CGMESProfile.hpp"
+
+class BaseClass;
+class AttrDetails;
+
+class CimClassDetails
+{
+public:
+	CimClassDetails(
+		const BaseClass& obj,
+		std::string classNamespace,
+		std::list<CGMESProfile> possibleProfiles,
+		CGMESProfile recommendedProfile);
+
+	const std::string ClassNamespace;
+	const std::map<std::string, AttrDetails> AttrDetailsMap;
+	const std::list<std::string> AttrNamesList;
+	const std::list<CGMESProfile> PossibleProfiles;
+	const CGMESProfile RecommendedProfile;
+	const std::list<CGMESProfile> PossibleProfilesIncludingAttributes;
+
+	const std::string& getAttributeNamespaceUrl(const std::string& attrName) const;
+	const std::list<CGMESProfile>& getPossibleAttributeProfiles(const std::string& attrName) const;
+
+private:
+	static std::list<std::string> constructAttrNamesList(const std::map<std::string, AttrDetails>& attrDetailsMap);
+	static std::list<CGMESProfile> constructPossibleProfilesIncludingAttributes(
+		const std::list<CGMESProfile>& possibleProfiles,
+		const std::map<std::string, AttrDetails>& attrDetailsMap);
+
+public:
+	static const std::list<std::string> UnknownAttributes;
+	static const std::string UnknownNamespace;
+	static const std::list<CGMESProfile> UnknownProfiles;
+};
+
+class AttrDetails
+{
+public:
+	AttrDetails(std::string n, std::list<CGMESProfile> c) : nameSpace(n), profiles(c) {}
+	const std::string nameSpace;
+	const std::list<CGMESProfile> profiles;
+};
+#endif

--- a/cimgen/languages/cpp/templates/cpp_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_header_template.mustache
@@ -12,6 +12,7 @@ Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cim
 #include "{{subclass_of}}.hpp"
 #include "BaseClassDefiner.hpp"
 #include "CGMESProfile.hpp"
+#include "CimClassDetails.hpp"
 {{#attribute_class_includes}}
 #include "{{.}}.hpp"
 {{/attribute_class_includes}}
@@ -54,8 +55,15 @@ namespace CIMPP
 		static const char debugName[];
 		const char* debugString() const override;
 
-		std::list<CGMESProfile> getPossibleProfilesForClass() const override;
-		std::map<std::string, std::list<CGMESProfile>> getPossibleProfilesForAttributes() const override;
+		const std::list<std::string>& getAttributeNames() const override;
+
+		const std::string& getClassNamespaceUrl() const override;
+		const std::string& getAttributeNamespaceUrl(const std::string& attrName) const override;
+
+		const std::list<CGMESProfile>& getPossibleProfiles() const override;
+		const CGMESProfile& getRecommendedProfile() const override;
+		const std::list<CGMESProfile>& getPossibleAttributeProfiles(const std::string& attrName) const override;
+		const std::list<CGMESProfile>& getPossibleProfilesIncludingAttributes() const override;
 
 		static void addConstructToMap(std::unordered_map<std::string, BaseClass* (*)()>& factory_map);
 		static void addPrimitiveAssignFnsToMap(std::unordered_map<std::string, assign_function>& assign_map);
@@ -64,6 +72,9 @@ namespace CIMPP
 		void addClassGetFnsToMap(std::map<std::string, class_get_function>& get_map) const override;
 		void addEnumGetFnsToMap(std::map<std::string, get_function>& get_map) const override;
 		static const BaseClassDefiner declare();
+
+	protected:
+		std::map<std::string, AttrDetails> allAttrDetailsMap() const override;
 	};
 
 	BaseClass* {{class_name}}_factory();

--- a/cimgen/languages/cpp/templates/cpp_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_header_template.mustache
@@ -71,6 +71,8 @@ namespace CIMPP
 		void addPrimitiveGetFnsToMap(std::map<std::string, get_function>& get_map) const override;
 		void addClassGetFnsToMap(std::map<std::string, class_get_function>& get_map) const override;
 		void addEnumGetFnsToMap(std::map<std::string, get_function>& get_map) const override;
+
+		bool isAssignableFrom(BaseClass* otherObject) const override;
 		static const BaseClassDefiner declare();
 
 	protected:

--- a/cimgen/languages/cpp/templates/cpp_object_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_object_template.mustache
@@ -357,6 +357,12 @@ void {{class_name}}::addEnumGetFnsToMap(std::map<std::string, get_function>& get
 {{/attributes}}
 }
 
+bool {{class_name}}::isAssignableFrom(BaseClass* otherObject) const
+{
+	return std::string(debugString()) == "{{class_name}}" &&
+		dynamic_cast<{{class_name}}*>(otherObject) != nullptr;
+}
+
 const BaseClassDefiner {{class_name}}::declare()
 {
 	return BaseClassDefiner({{class_name}}::addConstructToMap, {{class_name}}::addPrimitiveAssignFnsToMap, {{class_name}}::addClassAssignFnsToMap, {{class_name}}::debugName);

--- a/cimgen/languages/cpp/templates/cpp_object_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_object_template.mustache
@@ -14,36 +14,68 @@ Generated from the CGMES files via cimgen: https://github.com/sogno-platform/cim
 
 using namespace CIMPP;
 
+static const CimClassDetails& getCimClassDetails()
+{
+	static const CimClassDetails ClassDetails = CimClassDetails(
+		{{class_name}}(),
+		"{{class_namespace}}",
+		{
+{{#class_origin}}
+			CGMESProfile::{{origin}},
+{{/class_origin}}
+		},
+		CGMESProfile::{{recommended_class_profile}}
+	);
+	return ClassDetails;
+}
+
+static const std::map<std::string, AttrDetails>& getClassAttrDetailsMap()
+{
+	static const std::map<std::string, AttrDetails> ClassAttrDetailsMap =
+	{
+{{#attributes}}
+		{ "{{domain}}.{{label}}", { "{{attribute_namespace}}", { {{#attr_origin}}CGMESProfile::{{origin}}, {{/attr_origin}}} } },
+{{/attributes}}
+	};
+    return ClassAttrDetailsMap;
+}
+
 {{class_name}}::{{class_name}}(){{nullptr_assigns}} {}
 {{class_name}}::~{{class_name}}() {}
 
-static const std::list<CGMESProfile> PossibleProfilesForClass =
+const std::list<std::string>& {{class_name}}::getAttributeNames() const
 {
-{{#class_origin}}
-	CGMESProfile::{{origin}},
-{{/class_origin}}
-};
-
-static const std::map<std::string, std::list<CGMESProfile>> PossibleProfilesForAttributes =
-{
-{{#attributes}}
-	{ "{{domain}}.{{label}}", { {{#attr_origin}}CGMESProfile::{{origin}}, {{/attr_origin}}} },
-{{/attributes}}
-};
-
-std::list<CGMESProfile>
-{{class_name}}::getPossibleProfilesForClass() const
-{
-	return PossibleProfilesForClass;
+	return getCimClassDetails().AttrNamesList;
 }
 
-std::map<std::string, std::list<CGMESProfile>>
-{{class_name}}::getPossibleProfilesForAttributes() const
+const std::string& {{class_name}}::getClassNamespaceUrl() const
 {
-	auto map = PossibleProfilesForAttributes;
-	auto&& parent_map = {{subclass_of}}::getPossibleProfilesForAttributes();
-	map.insert(parent_map.begin(), parent_map.end());
-	return map;
+	return getCimClassDetails().ClassNamespace;
+}
+
+const std::string& {{class_name}}::getAttributeNamespaceUrl(const std::string& attrName) const
+{
+	return getCimClassDetails().getAttributeNamespaceUrl(attrName);
+}
+
+const std::list<CGMESProfile>& {{class_name}}::getPossibleProfiles() const
+{
+	return getCimClassDetails().PossibleProfiles;
+}
+
+const CGMESProfile& {{class_name}}::getRecommendedProfile() const
+{
+	return getCimClassDetails().RecommendedProfile;
+}
+
+const std::list<CGMESProfile>& {{class_name}}::getPossibleAttributeProfiles(const std::string& attrName) const
+{
+	return getCimClassDetails().getPossibleAttributeProfiles(attrName);
+}
+
+const std::list<CGMESProfile>& {{class_name}}::getPossibleProfilesIncludingAttributes() const
+{
+	return getCimClassDetails().PossibleProfilesIncludingAttributes;
 }
 
 {{#attributes}}
@@ -328,6 +360,14 @@ void {{class_name}}::addEnumGetFnsToMap(std::map<std::string, get_function>& get
 const BaseClassDefiner {{class_name}}::declare()
 {
 	return BaseClassDefiner({{class_name}}::addConstructToMap, {{class_name}}::addPrimitiveAssignFnsToMap, {{class_name}}::addClassAssignFnsToMap, {{class_name}}::debugName);
+}
+
+std::map<std::string, AttrDetails> {{class_name}}::allAttrDetailsMap() const
+{
+	auto map = getClassAttrDetailsMap();
+	const auto& parent_map = {{subclass_of}}::allAttrDetailsMap();
+	map.insert(parent_map.begin(), parent_map.end());
+	return map;
 }
 
 namespace CIMPP

--- a/cimgen/languages/cpp/templates/cpp_object_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_object_template.mustache
@@ -27,7 +27,7 @@ static const std::list<CGMESProfile> PossibleProfilesForClass =
 static const std::map<std::string, std::list<CGMESProfile>> PossibleProfilesForAttributes =
 {
 {{#attributes}}
-	{ "cim:{{about}}", { {{#attr_origin}}CGMESProfile::{{origin}}, {{/attr_origin}}} },
+	{ "{{domain}}.{{label}}", { {{#attr_origin}}CGMESProfile::{{origin}}, {{/attr_origin}}} },
 {{/attributes}}
 };
 
@@ -257,20 +257,20 @@ const char* {{class_name}}::debugString() const
 
 void {{class_name}}::addConstructToMap(std::unordered_map<std::string, BaseClass* (*)()>& factory_map)
 {
-	factory_map.emplace("cim:{{class_name}}", &{{class_name}}_factory);
+	factory_map.emplace("{{class_name}}", &{{class_name}}_factory);
 }
 
 void {{class_name}}::addPrimitiveAssignFnsToMap(std::unordered_map<std::string, assign_function>& assign_map)
 {
 {{#attributes}}
 {{#is_primitive_attribute}}
-	assign_map.emplace("cim:{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
+	assign_map.emplace("{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
 {{/is_primitive_attribute}}
 {{#is_datatype_attribute}}
-	assign_map.emplace("cim:{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
+	assign_map.emplace("{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
 {{/is_datatype_attribute}}
 {{#is_enum_attribute}}
-	assign_map.emplace("cim:{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
+	assign_map.emplace("{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
 {{/is_enum_attribute}}
 {{/attributes}}
 }
@@ -279,10 +279,10 @@ void {{class_name}}::addClassAssignFnsToMap(std::unordered_map<std::string, clas
 {
 {{#attributes}}
 {{#is_class_attribute}}
-	assign_map.emplace("cim:{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
+	assign_map.emplace("{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
 {{/is_class_attribute}}
 {{#is_list_attribute}}
-	assign_map.emplace("cim:{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
+	assign_map.emplace("{{domain}}.{{label}}", &assign_{{domain}}_{{label}});
 {{/is_list_attribute}}
 {{/attributes}}
 }
@@ -292,10 +292,10 @@ void {{class_name}}::addPrimitiveGetFnsToMap(std::map<std::string, get_function>
 	{{subclass_of}}::addPrimitiveGetFnsToMap(get_map);
 {{#attributes}}
 {{#is_primitive_attribute}}
-	get_map.emplace("cim:{{domain}}.{{label}}", &get_{{domain}}_{{label}});
+	get_map.emplace("{{domain}}.{{label}}", &get_{{domain}}_{{label}});
 {{/is_primitive_attribute}}
 {{#is_datatype_attribute}}
-	get_map.emplace("cim:{{domain}}.{{label}}", &get_{{domain}}_{{label}});
+	get_map.emplace("{{domain}}.{{label}}", &get_{{domain}}_{{label}});
 {{/is_datatype_attribute}}
 {{/attributes}}
 }
@@ -306,10 +306,10 @@ void {{class_name}}::addClassGetFnsToMap(std::map<std::string, class_get_functio
 {{#attributes}}
 {{#is_used}}
 {{#is_class_attribute}}
-	get_map.emplace("cim:{{domain}}.{{label}}", &get_{{domain}}_{{label}});
+	get_map.emplace("{{domain}}.{{label}}", &get_{{domain}}_{{label}});
 {{/is_class_attribute}}
 {{#is_list_attribute}}
-	get_map.emplace("cim:{{domain}}.{{label}}", &get_{{domain}}_{{label}});
+	get_map.emplace("{{domain}}.{{label}}", &get_{{domain}}_{{label}});
 {{/is_list_attribute}}
 {{/is_used}}
 {{/attributes}}
@@ -320,7 +320,7 @@ void {{class_name}}::addEnumGetFnsToMap(std::map<std::string, get_function>& get
 	{{subclass_of}}::addEnumGetFnsToMap(get_map);
 {{#attributes}}
 {{#is_enum_attribute}}
-	get_map.emplace("cim:{{domain}}.{{label}}", &get_{{domain}}_{{label}});
+	get_map.emplace("{{domain}}.{{label}}", &get_{{domain}}_{{label}});
 {{/is_enum_attribute}}
 {{/attributes}}
 }


### PR DESCRIPTION
- Fix custom namespace in cpp reader (e.g. entsoe in CGMES2, eu in CGMES3)
- Fix custom namespace in cpp writer (e.g. "entsoe" in CGMES2, "eu" in CGMES3; using new generated functions getClassNamespaceUrl and getAttributeNamespaceUrl)
- Add function isAssignableFrom to fix parsing objects with changing types (e.g. first as Equipment, than as PowerTransformer)
