### PR TITLE
Fix default values

### DIFF
--- a/cimgen/cimgen.py
+++ b/cimgen/cimgen.py
@@ -509,15 +509,6 @@ def _write_files(class_details: dict, output_path: str) -> None:
         # If class is a subclass a super().__init__() is needed
         class_details["super_init"] = True
 
-    # The entry datatype for an attribute is only set for basic data types. If the entry is not set here, the attribute
-    # is a reference to another class and therefore the entry datatype is generated and set to the multiplicity
-    for i in range(len(class_details["attributes"])):
-        if (
-            "datatype" not in class_details["attributes"][i].keys()
-            and "multiplicity" in class_details["attributes"][i].keys()
-        ):
-            class_details["attributes"][i]["datatype"] = class_details["attributes"][i]["multiplicity"]
-
     class_details["lang_pack"].run_template(output_path, class_details)
 
 

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -175,16 +175,14 @@ def _default_value(attribute: dict) -> str:
     :param attribute:  Dictionary with information about an attribute of a class.
     :return:           Default value
     """
-    if attribute["attribute_class"] in ("MonthDay", "Status", "StreetAddress", "StreetDetail", "TownDetail"):
-        return "nullptr"
     if attribute["is_datatype_attribute"]:
-        return "nullptr"
+        return "0.0"
     if attribute["is_enum_attribute"]:
         return "0"
     if attribute["is_class_attribute"]:
-        return "0"
+        return "nullptr"
     if attribute["is_list_attribute"]:
-        return "0"
+        return "{}"
     # primitive attribute
     if attribute["attribute_class"] == "Integer":
         return "0"
@@ -193,7 +191,7 @@ def _default_value(attribute: dict) -> str:
     if attribute["attribute_class"] in ("Float", "Decimal"):
         return "0.0"
     # primitive string attribute
-    return "''"
+    return '""'
 
 
 def _attribute_is_primitive_or_datatype_or_enum(attribute: dict) -> bool:

--- a/cimgen/languages/cpp/lang_pack.py
+++ b/cimgen/languages/cpp/lang_pack.py
@@ -138,7 +138,7 @@ def _variable_name(label: str, class_name: str) -> str:
     :return:            Variable name
     """
     if label == "switch" or label == class_name:
-        label = "_" + label
+        label += "_"
     return label
 
 

--- a/cimgen/languages/cpp/templates/cpp_enum_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_enum_header_template.mustache
@@ -19,7 +19,7 @@ namespace CIMPP
 		{
 {{#enum_instances}}
 {{#comment}}
-			/** {{comment}} */
+			/** {{{comment}}} */
 {{/comment}}
 			{{label}},
 {{/enum_instances}}

--- a/cimgen/languages/cpp/templates/cpp_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_header_template.mustache
@@ -34,7 +34,7 @@ namespace CIMPP
 		~{{class_name}}() override;
 {{#attributes}}
 
-		/** \brief {{comment}} Default: {{{default_value}}} */
+		/** \brief {{{comment}}} Default: {{{default_value}}} */
 {{#is_primitive_attribute}}
 		CIMPP::{{attribute_class}} {{variable_name}};
 {{/is_primitive_attribute}}

--- a/cimgen/languages/cpp/templates/cpp_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_header_template.mustache
@@ -34,7 +34,7 @@ namespace CIMPP
 		~{{class_name}}() override;
 {{#attributes}}
 
-		/** \brief {{comment}} Default: {{default_value}} */
+		/** \brief {{comment}} Default: {{{default_value}}} */
 {{#is_primitive_attribute}}
 		CIMPP::{{attribute_class}} {{variable_name}};
 {{/is_primitive_attribute}}

--- a/cimgen/languages/cpp/templates/cpp_header_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_header_template.mustache
@@ -34,21 +34,21 @@ namespace CIMPP
 		~{{class_name}}() override;
 {{#attributes}}
 
-		/** \brief {{comment}} Default: {{> set_default}} */
+		/** \brief {{comment}} Default: {{default_value}} */
 {{#is_primitive_attribute}}
-		CIMPP::{{attribute_class}} {{> label_without_keyword}};
+		CIMPP::{{attribute_class}} {{variable_name}};
 {{/is_primitive_attribute}}
 {{#is_datatype_attribute}}
-		CIMPP::{{attribute_class}} {{label}};
+		CIMPP::{{attribute_class}} {{variable_name}};
 {{/is_datatype_attribute}}
 {{#is_enum_attribute}}
-		CIMPP::{{attribute_class}} {{label}};
+		CIMPP::{{attribute_class}} {{variable_name}};
 {{/is_enum_attribute}}
 {{#is_class_attribute}}
-		CIMPP::{{attribute_class}}* {{label}};
+		CIMPP::{{attribute_class}}* {{variable_name}};
 {{/is_class_attribute}}
 {{#is_list_attribute}}
-		std::list<CIMPP::{{attribute_class}}*> {{label}};
+		std::list<CIMPP::{{attribute_class}}*> {{variable_name}};
 {{/is_list_attribute}}
 {{/attributes}}
 

--- a/cimgen/languages/cpp/templates/cpp_object_template.mustache
+++ b/cimgen/languages/cpp/templates/cpp_object_template.mustache
@@ -85,12 +85,12 @@ bool assign_{{domain}}_{{label}}(std::stringstream& buffer, BaseClass* BaseClass
 	{{domain}}* element = dynamic_cast<{{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-{{#attribute_is_primitive_string}}
-		element->{{> label_without_keyword}} = buffer.str();
-{{/attribute_is_primitive_string}}
-{{^attribute_is_primitive_string}}
-		buffer >> element->{{> label_without_keyword}};
-{{/attribute_is_primitive_string}}
+{{#is_primitive_string}}
+		element->{{variable_name}} = buffer.str();
+{{/is_primitive_string}}
+{{^is_primitive_string}}
+		buffer >> element->{{variable_name}};
+{{/is_primitive_string}}
 		if (!buffer.fail())
 		{
 			return true;
@@ -105,7 +105,7 @@ bool assign_{{domain}}_{{label}}(std::stringstream& buffer, BaseClass* BaseClass
 	{{domain}}* element = dynamic_cast<{{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-		buffer >> element->{{label}};
+		buffer >> element->{{variable_name}};
 		if (!buffer.fail())
 		{
 			return true;
@@ -120,7 +120,7 @@ bool assign_{{domain}}_{{label}}(std::stringstream& buffer, BaseClass* BaseClass
 	{{domain}}* element = dynamic_cast<{{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-		buffer >> element->{{label}};
+		buffer >> element->{{variable_name}};
 		if (!buffer.fail())
 		{
 			return true;
@@ -138,9 +138,9 @@ bool assign_{{domain}}_{{label}}(BaseClass* BaseClass_ptr1, BaseClass* BaseClass
 	{{attribute_class}}* element2 = dynamic_cast<{{attribute_class}}*>(BaseClass_ptr2);
 	if (element != nullptr && element2 != nullptr)
 	{
-		if (element->{{label}} != element2)
+		if (element->{{variable_name}} != element2)
 		{
-			element->{{label}} = element2;
+			element->{{variable_name}} = element2;
 			return assign_{{.}}(BaseClass_ptr2, BaseClass_ptr1);
 		}
 		return true;
@@ -154,8 +154,8 @@ bool assign_{{domain}}_{{label}}(BaseClass* BaseClass_ptr1, BaseClass* BaseClass
 	{{domain}}* element = dynamic_cast<{{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-		element->{{label}} = dynamic_cast<{{attribute_class}}*>(BaseClass_ptr2);
-		if (element->{{label}} != nullptr)
+		element->{{variable_name}} = dynamic_cast<{{attribute_class}}*>(BaseClass_ptr2);
+		if (element->{{variable_name}} != nullptr)
 		{
 			return true;
 		}
@@ -173,9 +173,9 @@ bool assign_{{domain}}_{{label}}(BaseClass* BaseClass_ptr1, BaseClass* BaseClass
 	{{attribute_class}}* element2 = dynamic_cast<{{attribute_class}}*>(BaseClass_ptr2);
 	if (element != nullptr && element2 != nullptr)
 	{
-		if (std::find(element->{{label}}.begin(), element->{{label}}.end(), element2) == element->{{label}}.end())
+		if (std::find(element->{{variable_name}}.begin(), element->{{variable_name}}.end(), element2) == element->{{variable_name}}.end())
 		{
-			element->{{label}}.push_back(element2);
+			element->{{variable_name}}.push_back(element2);
 			return assign_{{.}}(BaseClass_ptr2, BaseClass_ptr1);
 		}
 		return true;
@@ -191,7 +191,7 @@ bool assign_{{domain}}_{{label}}(BaseClass* BaseClass_ptr1, BaseClass* BaseClass
 	{
 		if (dynamic_cast<{{attribute_class}}*>(BaseClass_ptr2) != nullptr)
 		{
-			element->{{label}}.push_back(dynamic_cast<{{attribute_class}}*>(BaseClass_ptr2));
+			element->{{variable_name}}.push_back(dynamic_cast<{{attribute_class}}*>(BaseClass_ptr2));
 			return true;
 		}
 	}
@@ -209,7 +209,7 @@ bool get_{{domain}}_{{label}}(const BaseClass* BaseClass_ptr1, std::stringstream
 	const {{domain}}* element = dynamic_cast<const {{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-		buffer << element->{{> label_without_keyword}};
+		buffer << element->{{variable_name}};
 		if (!buffer.str().empty())
 		{
 			return true;
@@ -225,7 +225,7 @@ bool get_{{domain}}_{{label}}(const BaseClass* BaseClass_ptr1, std::stringstream
 	const {{domain}}* element = dynamic_cast<const {{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-		buffer << element->{{label}};
+		buffer << element->{{variable_name}};
 		if (!buffer.str().empty())
 		{
 			return true;
@@ -241,7 +241,7 @@ bool get_{{domain}}_{{label}}(const BaseClass* BaseClass_ptr1, std::stringstream
 	const {{domain}}* element = dynamic_cast<const {{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-		buffer << element->{{label}};
+		buffer << element->{{variable_name}};
 		if (!buffer.str().empty())
 		{
 			return true;
@@ -257,9 +257,9 @@ bool get_{{domain}}_{{label}}(const BaseClass* BaseClass_ptr1, std::list<const B
 	const {{domain}}* element = dynamic_cast<const {{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-		if (element->{{label}} != 0)
+		if (element->{{variable_name}} != 0)
 		{
-			BaseClass_list.push_back(element->{{label}});
+			BaseClass_list.push_back(element->{{variable_name}});
 			return true;
 		}
 	}
@@ -272,7 +272,7 @@ bool get_{{domain}}_{{label}}(const BaseClass* BaseClass_ptr1, std::list<const B
 	const {{domain}}* element = dynamic_cast<const {{domain}}*>(BaseClass_ptr1);
 	if (element != nullptr)
 	{
-		std::copy(element->{{label}}.begin(), element->{{label}}.end(), std::back_inserter(BaseClass_list));
+		std::copy(element->{{variable_name}}.begin(), element->{{variable_name}}.end(), std::back_inserter(BaseClass_list));
 		return !BaseClass_list.empty();
 	}
 	return false;

--- a/cimgen/languages/modernpython/templates/class_template.mustache
+++ b/cimgen/languages/modernpython/templates/class_template.mustache
@@ -23,8 +23,8 @@ class {{class_name}}({{subclass_of}}):
     """
 
     {{#attributes}}
-    {{label}}: {{#set_type}}{{.}}{{/set_type}} = Field(
-        {{#set_default}}{{.}}{{/set_default}},
+    {{label}}: {{python_type}} = Field(
+        {{{default_value}}},
         json_schema_extra={
             "in_profiles": [
                 {{#attr_origin}}

--- a/cimgen/languages/modernpython/templates/enum_template.mustache
+++ b/cimgen/languages/modernpython/templates/enum_template.mustache
@@ -11,5 +11,5 @@ class {{class_name}}(str, Enum):
     """
 
     {{#enum_instances}}
-    {{label}} = "{{label}}"{{#comment}}  # {{comment}}{{/comment}}
+    {{label}} = "{{label}}"{{#comment}}  # {{{comment}}}{{/comment}}
     {{/enum_instances}}

--- a/cimgen/languages/python/lang_pack.py
+++ b/cimgen/languages/python/lang_pack.py
@@ -102,8 +102,6 @@ def _default_value(attribute: dict) -> str:
     :param attribute:  Dictionary with information about an attribute of a class.
     :return:           Default value
     """
-    if attribute["attribute_class"] in ("MonthDay", "Status", "StreetAddress", "StreetDetail", "TownDetail"):
-        return "0.0"
     if attribute["is_datatype_attribute"]:
         return "0.0"
     if attribute["is_enum_attribute"]:
@@ -120,7 +118,7 @@ def _default_value(attribute: dict) -> str:
     if attribute["attribute_class"] in ("Float", "Decimal"):
         return "0.0"
     # primitive string attribute
-    return "''"
+    return '""'
 
 
 class_blacklist = ["CGMESProfile", "CimConstants"]

--- a/cimgen/languages/python/templates/cimpy_class_template.mustache
+++ b/cimgen/languages/python/templates/cimpy_class_template.mustache
@@ -7,7 +7,7 @@ class {{class_name}}({{subclass_of}}):
     {{{class_comment}}}
 
 {{#attributes}}
-    :{{label}}: {{{comment}}} Default: {{#set_default}}{{datatype}}{{/set_default}}
+    :{{label}}: {{{comment}}} Default: {{{default_value}}}
 {{/attributes}}
     """
 
@@ -26,7 +26,7 @@ class {{class_name}}({{subclass_of}}):
     __doc__ += "\nDocumentation of parent class {{subclass_of}}:\n" + {{subclass_of}}.__doc__
 {{/super_init}}
 
-    def __init__(self{{#attributes}}, {{label}} = {{#set_default}}{{datatype}}{{/set_default}}{{/attributes}}{{#super_init}}, *args, **kw_args{{/super_init}}):
+    def __init__(self{{#attributes}}, {{label}} = {{{default_value}}}{{/attributes}}{{#super_init}}, *args, **kw_args{{/super_init}}):
 {{#super_init}}
         super().__init__(*args, **kw_args)
 {{/super_init}}


### PR DESCRIPTION
- Improve setting of default values for cpp, modernpython and python (generated code is unchanged)
- Remove the unnecessary and misleading copying from muliplicity to dataType (generated code is unchanged) (fixing #28)
- Fix default values for cpp and python
- Change variable name for switch from `_switch` to `switch_` (unified with java)
- Fix attribute and enum comments for cpp
- Fix enum comments for modernpython